### PR TITLE
Add tank and priest enemy roles

### DIFF
--- a/scripts/ai.js
+++ b/scripts/ai.js
@@ -1,20 +1,132 @@
-import { GAME_CONFIG, MILITIA_STATS, SCOUT_STATS } from './constants.js';
+import { GAME_CONFIG, MILITIA_STATS } from './constants.js';
 import { gameState } from './state.js';
 import { distance, isPointInRect } from './utils.js';
 
-function canScoutSeeHero(scout) {
-    const distToHero = distance(gameState.hero.x, gameState.hero.y, scout.x, scout.y);
-    if (distToHero <= SCOUT_STATS.criticalSightRange) {
+function getHeroCenter() {
+    return {
+        x: gameState.hero.x + gameState.hero.width / 2,
+        y: gameState.hero.y + gameState.hero.height / 2
+    };
+}
+
+function canMinionSeeHero(minion) {
+    const heroCenter = getHeroCenter();
+    const distToHero = distance(heroCenter.x, heroCenter.y, minion.x, minion.y);
+    if (distToHero <= minion.criticalSightRange) {
         return true;
     }
-    if (distToHero > SCOUT_STATS.sightRange) {
+    if (distToHero > minion.sightRange) {
         return false;
     }
     const heroInForest = gameState.forests.some((forest) => isPointInRect(gameState.hero, forest));
     return !heroInForest;
 }
 
+function getTargetPosition(target) {
+    if (typeof target.width === 'number' && typeof target.height === 'number') {
+        return { x: target.x + target.width / 2, y: target.y + target.height / 2 };
+    }
+    return { x: target.x, y: target.y };
+}
+
+function findNearestAlly(minion) {
+    let nearest = null;
+    let bestScore = Infinity;
+    gameState.scouts.forEach((ally) => {
+        if (ally.id === minion.id) {
+            return;
+        }
+        const dist = distance(ally.x, ally.y, minion.x, minion.y);
+        const weight = ally.role === 'tank' ? 0.6 : 1;
+        const score = dist * weight;
+        if (score < bestScore) {
+            bestScore = score;
+            nearest = ally;
+        }
+    });
+    return nearest;
+}
+
+function getFollowPoint(minion, ally) {
+    if (!ally) {
+        return { x: gameState.hero.x, y: gameState.hero.y };
+    }
+    const followDistance = minion.followDistance || 0;
+    if (followDistance <= 0) {
+        return { x: ally.x, y: ally.y };
+    }
+    const dx = ally.x - minion.x;
+    const dy = ally.y - minion.y;
+    const dist = Math.sqrt(dx * dx + dy * dy) || 1;
+    const offsetX = (dx / dist) * followDistance;
+    const offsetY = (dy / dist) * followDistance;
+    return {
+        x: ally.x - offsetX,
+        y: ally.y - offsetY
+    };
+}
+
+function shouldTankSwing(tank) {
+    const heroCenter = getHeroCenter();
+    if (distance(heroCenter.x, heroCenter.y, tank.x, tank.y) <= tank.swingRadius) {
+        return true;
+    }
+    for (const village of gameState.villages) {
+        for (const unit of village.militia) {
+            const { x, y } = getTargetPosition(unit);
+            if (distance(x, y, tank.x, tank.y) <= tank.swingRadius) {
+                return true;
+            }
+        }
+        for (const villager of village.villagers) {
+            const { x, y } = getTargetPosition(villager);
+            if (distance(x, y, tank.x, tank.y) <= tank.swingRadius + villager.radius) {
+                return true;
+            }
+        }
+        for (const hut of village.huts) {
+            const { x, y } = getTargetPosition(hut);
+            const hutRadius = Math.max(hut.width, hut.height) / 2;
+            if (distance(x, y, tank.x, tank.y) <= tank.swingRadius + hutRadius) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+function performTankSwing(tank) {
+    const heroCenter = getHeroCenter();
+    if (distance(heroCenter.x, heroCenter.y, tank.x, tank.y) <= tank.swingRadius) {
+        gameState.hero.hp -= tank.damage;
+    }
+
+    gameState.villages.forEach((village) => {
+        village.militia.forEach((militiaman) => {
+            const { x, y } = getTargetPosition(militiaman);
+            if (distance(x, y, tank.x, tank.y) <= tank.swingRadius) {
+                militiaman.hp = Math.max(0, militiaman.hp - tank.damage);
+            }
+        });
+        village.villagers.forEach((villager) => {
+            const { x, y } = getTargetPosition(villager);
+            if (distance(x, y, tank.x, tank.y) <= tank.swingRadius + villager.radius) {
+                villager.hp = Math.max(0, villager.hp - tank.damage * 0.75);
+            }
+        });
+        village.huts.forEach((hut) => {
+            const { x, y } = getTargetPosition(hut);
+            const hutRadius = Math.max(hut.width, hut.height) / 2;
+            if (distance(x, y, tank.x, tank.y) <= tank.swingRadius + hutRadius) {
+                hut.hp = Math.max(0, hut.hp - tank.damage * tank.structureDamageMultiplier);
+            }
+        });
+    });
+}
+
 export function updateHero(deltaTime) {
+    gameState.hero.revealTimer = Math.max(0, gameState.hero.revealTimer - deltaTime);
+
     const dx = gameState.hero.targetX - gameState.hero.x;
     const dy = gameState.hero.targetY - gameState.hero.y;
     const dist = Math.sqrt(dx * dx + dy * dy);
@@ -54,7 +166,11 @@ export function updateMilitiaAI(deltaTime) {
         village.militia.forEach((militiaman) => {
             militiaman.attackTimer -= deltaTime;
             if (village.isUnderAttack) {
-                if (!militiaman.targetScout || militiaman.targetScout.hp <= 0 || !village.attackers.has(militiaman.targetScout.id)) {
+                if (
+                    !militiaman.targetScout ||
+                    militiaman.targetScout.hp <= 0 ||
+                    !village.attackers.has(militiaman.targetScout.id)
+                ) {
                     militiaman.targetScout = gameState.scouts.find((scout) => village.attackers.has(scout.id)) || null;
                 }
 
@@ -100,7 +216,8 @@ export function updateProjectiles(projectiles, speed, damage, owner) {
             projectile.y += (dy / dist) * speed;
         } else {
             projectiles.splice(i, 1);
-            target.hp -= damage;
+            const multiplier = target.damageMultipliers?.[owner] ?? 1;
+            target.hp = Math.max(0, target.hp - damage * multiplier);
             if (owner === 'hero') {
                 gameState.villages.forEach((village) => {
                     if (village.attackers.has(target.id)) {
@@ -113,22 +230,33 @@ export function updateProjectiles(projectiles, speed, damage, owner) {
 }
 
 export function updateScoutsAI(deltaTime) {
+    const heroCenter = getHeroCenter();
     gameState.scouts.forEach((scout) => {
         scout.villageAttackCooldown -= deltaTime;
         scout.heroAttackCooldown -= deltaTime;
+        if (typeof scout.healCooldownTimer === 'number') {
+            scout.healCooldownTimer -= deltaTime;
+        }
+        if (typeof scout.revealCooldownTimer === 'number') {
+            scout.revealCooldownTimer -= deltaTime;
+        }
 
         if (scout.state === 'PATROLLING') {
-            if (canScoutSeeHero(scout)) {
+            if (canMinionSeeHero(scout)) {
                 scout.state = 'CHASING';
             } else {
                 for (const village of gameState.villages) {
-                    const targets = [...village.villagers, ...village.huts];
+                    const targets =
+                        scout.role === 'tank'
+                            ? [...village.huts, ...village.villagers]
+                            : [...village.villagers, ...village.huts];
                     for (const target of targets) {
                         if (target.hp <= 0) {
                             continue;
                         }
-                        const distToTarget = distance(target.x, target.y, scout.x, scout.y);
-                        if (distToTarget <= SCOUT_STATS.sightRange) {
+                        const { x: targetX, y: targetY } = getTargetPosition(target);
+                        const distToTarget = distance(targetX, targetY, scout.x, scout.y);
+                        if (distToTarget <= scout.sightRange) {
                             scout.state = 'ATTACKING_VILLAGE';
                             scout.villageAttackTarget = target;
                             village.isUnderAttack = true;
@@ -142,36 +270,49 @@ export function updateScoutsAI(deltaTime) {
                 }
             }
 
-            if (scout.state !== 'PATROLLING' && !scout.isBuffed) {
+            if (scout.state !== 'PATROLLING' && !scout.isBuffed && scout.speedBuffMultiplier > 1) {
                 scout.isBuffed = true;
-                scout.speed *= SCOUT_STATS.speedBuffMultiplier;
-                scout.maxHp += SCOUT_STATS.hpBuffBonus;
-                scout.hp += SCOUT_STATS.hpBuffBonus;
+                scout.speed *= scout.speedBuffMultiplier;
+                scout.maxHp += scout.hpBuffBonus;
+                scout.hp += scout.hpBuffBonus;
                 scout.color = '#ff3333';
             }
         }
 
         if (scout.state === 'CHASING') {
-            scout.targetX = gameState.hero.x;
-            scout.targetY = gameState.hero.y;
+            if (scout.role === 'priest') {
+                const ally = findNearestAlly(scout);
+                const followPoint = getFollowPoint(scout, ally);
+                scout.targetX = followPoint.x;
+                scout.targetY = followPoint.y;
+            } else {
+                scout.targetX = gameState.hero.x;
+                scout.targetY = gameState.hero.y;
+            }
         } else if (scout.state === 'ATTACKING_VILLAGE') {
             if (!scout.villageAttackTarget || scout.villageAttackTarget.hp <= 0) {
                 scout.state = 'PATROLLING';
                 scout.villageAttackTarget = null;
             } else {
-                scout.targetX = scout.villageAttackTarget.x;
-                scout.targetY = scout.villageAttackTarget.y;
-                const distToTarget = distance(scout.targetX, scout.targetY, scout.x, scout.y);
-                if (distToTarget < 30 && scout.villageAttackCooldown <= 0) {
-                    scout.villageAttackTarget.hp -= SCOUT_STATS.villageAttackDamage;
-                    scout.villageAttackCooldown = SCOUT_STATS.villageAttackCooldown;
+                const { x: targetX, y: targetY } = getTargetPosition(scout.villageAttackTarget);
+                scout.targetX = targetX;
+                scout.targetY = targetY;
+                const distToTarget = distance(targetX, targetY, scout.x, scout.y);
+                if (distToTarget < scout.attackRange && scout.villageAttackCooldown <= 0) {
+                    const isStructure = typeof scout.villageAttackTarget.width === 'number';
+                    const damageMultiplier = isStructure ? scout.structureDamageMultiplier : 1;
+                    scout.villageAttackTarget.hp = Math.max(
+                        0,
+                        scout.villageAttackTarget.hp - scout.villageAttackDamage * damageMultiplier
+                    );
+                    scout.villageAttackCooldown = scout.villageAttackCooldownMax;
                 }
             }
         } else if (scout.state === 'PATROLLING') {
             const distToTarget = distance(scout.targetX, scout.targetY, scout.x, scout.y);
             if (distToTarget < 20) {
-                scout.targetX = scout.patrolCenterX + (Math.random() - 0.5) * 2 * SCOUT_STATS.patrolRadius;
-                scout.targetY = scout.patrolCenterY + (Math.random() - 0.5) * 2 * SCOUT_STATS.patrolRadius;
+                scout.targetX = scout.patrolCenterX + (Math.random() - 0.5) * 2 * scout.patrolRadius;
+                scout.targetY = scout.patrolCenterY + (Math.random() - 0.5) * 2 * scout.patrolRadius;
             }
         }
 
@@ -180,7 +321,7 @@ export function updateScoutsAI(deltaTime) {
         const dist = Math.sqrt(dx * dx + dy * dy);
 
         let shouldMove = true;
-        if (scout.state === 'CHASING' && dist < 30 && scout.heroAttackCooldown > 0) {
+        if (scout.role !== 'priest' && scout.state === 'CHASING' && dist < scout.attackRange && scout.heroAttackCooldown > 0) {
             shouldMove = false;
         }
 
@@ -188,16 +329,79 @@ export function updateScoutsAI(deltaTime) {
             scout.x += (dx / dist) * scout.speed;
             scout.y += (dy / dist) * scout.speed;
         }
+
+        if (
+            scout.role === 'priest' &&
+            scout.healAmount &&
+            scout.healRadius &&
+            scout.healCooldown &&
+            scout.healCooldownTimer <= 0
+        ) {
+            let healedAny = false;
+            gameState.scouts.forEach((ally) => {
+                if (ally.id === scout.id) {
+                    return;
+                }
+                const allyDist = distance(ally.x, ally.y, scout.x, scout.y);
+                if (allyDist <= scout.healRadius) {
+                    const missingHp = ally.maxHp - ally.hp;
+                    if (missingHp > 0) {
+                        ally.hp = Math.min(ally.maxHp, ally.hp + scout.healAmount);
+                        healedAny = true;
+                    }
+                }
+            });
+            if (healedAny) {
+                scout.healCooldownTimer = scout.healCooldown;
+                gameState.worldTextEffects.push({
+                    text: '+',
+                    x: scout.x,
+                    y: scout.y - 20,
+                    color: 'rgba(200, 240, 255, 0.9)',
+                    font: 'bold 18px MedievalSharp',
+                    lifespan: 0.6
+                });
+            } else {
+                scout.healCooldownTimer = 1;
+            }
+        }
+
+        if (
+            scout.role === 'priest' &&
+            scout.revealDuration &&
+            scout.revealCooldown &&
+            scout.revealCooldownTimer <= 0 &&
+            canMinionSeeHero(scout)
+        ) {
+            gameState.hero.revealTimer = Math.max(gameState.hero.revealTimer, scout.revealDuration);
+            scout.revealCooldownTimer = scout.revealCooldown;
+            gameState.worldTextEffects.push({
+                text: 'Revealed!',
+                x: heroCenter.x,
+                y: heroCenter.y - 30,
+                color: 'rgba(255, 215, 0, 0.9)',
+                font: 'bold 18px MedievalSharp',
+                lifespan: 1
+            });
+        }
     });
 }
 
 export function handleCollisionsAndDeaths() {
+    const heroCenter = getHeroCenter();
     for (let i = gameState.scouts.length - 1; i >= 0; i -= 1) {
         const scout = gameState.scouts[i];
-        const distToHero = distance(scout.x, scout.y, gameState.hero.x + gameState.hero.width / 2, gameState.hero.y + gameState.hero.height / 2);
-        if (distToHero < scout.radius + gameState.hero.width / 2 && scout.heroAttackCooldown <= 0) {
-            gameState.hero.hp -= SCOUT_STATS.damage;
-            scout.heroAttackCooldown = SCOUT_STATS.heroAttackCooldown;
+        if (scout.role === 'tank') {
+            if (scout.heroAttackCooldown <= 0 && scout.swingRadius && shouldTankSwing(scout)) {
+                performTankSwing(scout);
+                scout.heroAttackCooldown = scout.heroAttackCooldownMax;
+            }
+        } else {
+            const distToHero = distance(scout.x, scout.y, heroCenter.x, heroCenter.y);
+            if (distToHero < scout.attackRange && scout.heroAttackCooldown <= 0) {
+                gameState.hero.hp -= scout.damage;
+                scout.heroAttackCooldown = scout.heroAttackCooldownMax;
+            }
         }
     }
 
@@ -254,6 +458,11 @@ export function handleCollisionsAndDeaths() {
         for (let i = village.villagers.length - 1; i >= 0; i -= 1) {
             if (village.villagers[i].hp <= 0) {
                 village.villagers.splice(i, 1);
+            }
+        }
+        for (let i = village.militia.length - 1; i >= 0; i -= 1) {
+            if (village.militia[i].hp <= 0) {
+                village.militia.splice(i, 1);
             }
         }
     });

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -46,19 +46,83 @@ export const SHOP_ITEMS = [
     { id: 'hp1', name: 'Tough Jerky', cost: 100, effect: { stat: 'maxHp', value: 25 }, description: '+25 Max HP', icon: '🍖' }
 ];
 
-export const SCOUT_STATS = {
-    maxHp: 40,
-    damage: 10,
-    sightRange: 400,
-    criticalSightRange: 80,
-    patrolRadius: 200,
-    baseSpeed: 1.8,
-    speedBuffMultiplier: 1.5,
-    hpBuffBonus: 60,
-    villageAttackDamage: 5,
-    villageAttackCooldown: 1,
-    heroAttackCooldown: 1.5
+export const MINION_TYPES = {
+    scout: {
+        role: 'scout',
+        color: '#e24a4a',
+        radius: 10,
+        maxHp: 40,
+        damage: 10,
+        sightRange: 400,
+        criticalSightRange: 80,
+        patrolRadius: 200,
+        baseSpeed: 1.8,
+        speedBuffMultiplier: 1.5,
+        hpBuffBonus: 60,
+        villageAttackDamage: 5,
+        villageAttackCooldown: 1,
+        heroAttackCooldown: 1.5,
+        attackRange: 30,
+        damageMultipliers: {
+            militia: 1,
+            hero: 1
+        }
+    },
+    tank: {
+        role: 'tank',
+        color: '#6b4b2d',
+        radius: 14,
+        maxHp: 220,
+        damage: 18,
+        sightRange: 320,
+        criticalSightRange: 60,
+        patrolRadius: 160,
+        baseSpeed: 1.1,
+        villageAttackDamage: 15,
+        villageAttackCooldown: 1.2,
+        heroAttackCooldown: 2.8,
+        attackRange: 45,
+        swingRadius: 70,
+        structureDamageMultiplier: 1.35,
+        damageMultipliers: {
+            militia: 0.35,
+            hero: 1
+        }
+    },
+    priest: {
+        role: 'priest',
+        color: '#b6a6ff',
+        radius: 10,
+        maxHp: 70,
+        damage: 6,
+        sightRange: 380,
+        criticalSightRange: 90,
+        patrolRadius: 180,
+        baseSpeed: 1.6,
+        villageAttackDamage: 3,
+        villageAttackCooldown: 1.5,
+        heroAttackCooldown: 2.2,
+        attackRange: 28,
+        healAmount: 15,
+        healRadius: 150,
+        healCooldown: 3.5,
+        revealDuration: 1.5,
+        revealCooldown: 5,
+        followDistance: 55,
+        damageMultipliers: {
+            militia: 1,
+            hero: 1
+        }
+    }
 };
+
+export const MINION_SPAWN_TABLE = [
+    { type: 'scout', weight: 0.55 },
+    { type: 'tank', weight: 0.25 },
+    { type: 'priest', weight: 0.2 }
+];
+
+export const SCOUT_STATS = MINION_TYPES.scout;
 
 export const MILITIA_STATS = {
     maxHp: 60,

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,5 +1,5 @@
-import { GAME_CONFIG, MILITIA_PROJECTILE_SPEED, MILITIA_STATS } from './constants.js';
-import { gameState, initializeGameState, resetHeroTarget, createScout } from './state.js';
+import { GAME_CONFIG, MILITIA_PROJECTILE_SPEED, MILITIA_STATS, MINION_SPAWN_TABLE } from './constants.js';
+import { gameState, initializeGameState, resetHeroTarget, createMinion } from './state.js';
 import { setupShop } from './shop.js';
 import { createInventorySlots, drawInventory, updateUI } from './ui.js';
 import { setupDragAndDrop, isDraggingItem, updateDraggedIconPosition } from './drag-drop.js';
@@ -8,8 +8,34 @@ import { updateWorldTextEffects } from './effects.js';
 import { updateCamera } from './camera.js';
 import { draw } from './render.js';
 
-function spawnScout() {
-    gameState.scouts.push(createScout());
+function pickMinionType() {
+    const totalWeight = MINION_SPAWN_TABLE.reduce((sum, entry) => sum + entry.weight, 0);
+    let roll = Math.random() * totalWeight;
+    for (const entry of MINION_SPAWN_TABLE) {
+        roll -= entry.weight;
+        if (roll <= 0) {
+            return entry.type;
+        }
+    }
+    return MINION_SPAWN_TABLE[0].type;
+}
+
+function spawnMinion(type) {
+    gameState.scouts.push(createMinion(type));
+}
+
+function spawnMinionWave() {
+    const baseCount = Math.random() < 0.45 ? 2 : 1;
+    const spawnedTypes = [];
+    for (let i = 0; i < baseCount; i += 1) {
+        const type = pickMinionType();
+        spawnMinion(type);
+        spawnedTypes.push(type);
+    }
+
+    if (spawnedTypes.includes('tank') && !spawnedTypes.includes('priest') && Math.random() < 0.6) {
+        spawnMinion('priest');
+    }
 }
 
 function resizeCanvas() {
@@ -72,7 +98,7 @@ function gameLoop(timestamp) {
 
     gameState.spawnTimer += deltaTime;
     if (gameState.spawnTimer >= GAME_CONFIG.darkLordSpawnCooldown) {
-        spawnScout();
+        spawnMinionWave();
         gameState.spawnTimer = 0;
     }
 

--- a/scripts/render.js
+++ b/scripts/render.js
@@ -1,4 +1,4 @@
-import { GAME_CONFIG, SCOUT_STATS } from './constants.js';
+import { GAME_CONFIG } from './constants.js';
 import { gameState } from './state.js';
 
 export function draw() {
@@ -69,6 +69,11 @@ export function draw() {
 
     ctx.fillStyle = gameState.hero.color;
     ctx.fillRect(gameState.hero.x, gameState.hero.y, gameState.hero.width, gameState.hero.height);
+    if (gameState.hero.revealTimer > 0) {
+        ctx.strokeStyle = 'rgba(255, 215, 0, 0.9)';
+        ctx.lineWidth = 3;
+        ctx.strokeRect(gameState.hero.x - 4, gameState.hero.y - 4, gameState.hero.width + 8, gameState.hero.height + 8);
+    }
 
     gameState.projectiles.forEach((projectile) => {
         ctx.beginPath();
@@ -85,15 +90,21 @@ export function draw() {
     });
 
     gameState.scouts.forEach((scout) => {
-        if (scout.state === 'PATROLLING') {
+        if (scout.role === 'scout' && scout.state === 'PATROLLING') {
             ctx.beginPath();
-            ctx.arc(scout.x, scout.y, SCOUT_STATS.sightRange, 0, Math.PI * 2);
+            ctx.arc(scout.x, scout.y, scout.sightRange, 0, Math.PI * 2);
             ctx.strokeStyle = 'rgba(255, 255, 0, 0.1)';
             ctx.stroke();
             ctx.beginPath();
-            ctx.arc(scout.x, scout.y, SCOUT_STATS.criticalSightRange, 0, Math.PI * 2);
+            ctx.arc(scout.x, scout.y, scout.criticalSightRange, 0, Math.PI * 2);
             ctx.fillStyle = 'rgba(255, 0, 0, 0.1)';
             ctx.fill();
+        }
+        if (scout.role === 'priest' && scout.healRadius) {
+            ctx.beginPath();
+            ctx.arc(scout.x, scout.y, scout.healRadius, 0, Math.PI * 2);
+            ctx.strokeStyle = 'rgba(180, 220, 255, 0.08)';
+            ctx.stroke();
         }
         ctx.beginPath();
         ctx.arc(scout.x, scout.y, scout.radius, 0, Math.PI * 2);

--- a/scripts/state.js
+++ b/scripts/state.js
@@ -11,8 +11,8 @@ import {
     HUTS_PER_VILLAGE,
     VILLAGERS_PER_VILLAGE,
     MILITIA_PER_VILLAGE,
-    SCOUT_STATS,
-    MILITIA_STATS
+    MILITIA_STATS,
+    MINION_TYPES
 } from './constants.js';
 
 export const gameState = {
@@ -40,6 +40,7 @@ function createHero() {
         targetX: HERO_BASE_STATS.x,
         targetY: HERO_BASE_STATS.y,
         attackTimer: 0,
+        revealTimer: 0,
         inventory: new Array(GAME_CONFIG.inventorySize).fill(null)
     };
 }
@@ -135,24 +136,56 @@ export function cloneShopItems() {
     gameState.shopItems = SHOP_ITEMS.map((item) => ({ ...item, effect: { ...item.effect } }));
 }
 
-export function createScout() {
+function getMinionSpawnPoint() {
+    return {
+        x: gameState.castle.x + gameState.castle.width / 2,
+        y: gameState.castle.y + gameState.castle.height / 2
+    };
+}
+
+export function createMinion(role = 'scout') {
+    const config = MINION_TYPES[role] || MINION_TYPES.scout;
+    const spawnPoint = getMinionSpawnPoint();
     return {
         id: Math.random(),
-        x: gameState.castle.x + gameState.castle.width / 2,
-        y: gameState.castle.y + gameState.castle.height / 2,
-        radius: 10,
-        color: '#e24a4a',
-        hp: SCOUT_STATS.maxHp,
-        maxHp: SCOUT_STATS.maxHp,
-        speed: SCOUT_STATS.baseSpeed,
+        role: config.role,
+        x: spawnPoint.x,
+        y: spawnPoint.y,
+        radius: config.radius,
+        color: config.color,
+        hp: config.maxHp,
+        maxHp: config.maxHp,
+        speed: config.baseSpeed,
+        baseSpeed: config.baseSpeed,
         isBuffed: false,
         state: 'PATROLLING',
         targetX: Math.random() * WORLD.width,
         targetY: Math.random() * WORLD.height,
         patrolCenterX: Math.random() * WORLD.width,
         patrolCenterY: Math.random() * WORLD.height,
+        patrolRadius: config.patrolRadius,
+        sightRange: config.sightRange,
+        criticalSightRange: config.criticalSightRange,
         villageAttackTarget: null,
         villageAttackCooldown: 0,
-        heroAttackCooldown: 0
+        villageAttackCooldownMax: config.villageAttackCooldown,
+        villageAttackDamage: config.villageAttackDamage,
+        heroAttackCooldown: 0,
+        heroAttackCooldownMax: config.heroAttackCooldown,
+        attackRange: config.attackRange ?? config.radius + 20,
+        damage: config.damage,
+        damageMultipliers: { militia: 1, hero: 1, ...(config.damageMultipliers || {}) },
+        swingRadius: config.swingRadius ?? null,
+        structureDamageMultiplier: config.structureDamageMultiplier ?? 1,
+        healAmount: config.healAmount ?? null,
+        healRadius: config.healRadius ?? null,
+        healCooldown: config.healCooldown ?? null,
+        healCooldownTimer: config.healCooldown ?? 0,
+        revealDuration: config.revealDuration ?? null,
+        revealCooldown: config.revealCooldown ?? null,
+        revealCooldownTimer: 0,
+        followDistance: config.followDistance ?? 0,
+        speedBuffMultiplier: config.speedBuffMultiplier ?? 1,
+        hpBuffBonus: config.hpBuffBonus ?? 0
     };
 }


### PR DESCRIPTION
## Summary
- define new tank and priest minion roles with spawn weighting and role-specific stats
- expand AI to support tank door-breaking swings, priest healing and reveal pulses, and expose hero reveal state
- update rendering and hero state to visualize reveal effects and account for role-specific targeting

## Testing
- node --check scripts/ai.js
- node --check scripts/main.js
- node --check scripts/render.js
- node --check scripts/state.js
- node --check scripts/constants.js

------
https://chatgpt.com/codex/tasks/task_e_68dec67b5a508332bdef7302e098edfb