### PR TITLE
Add run end conditions and UI for campaign flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,34 @@
     <div id="gameContainer" class="w-full max-w-5xl mx-auto flex-grow relative rounded-lg overflow-hidden">
         <canvas id="gameCanvas"></canvas>
 
+        <div class="absolute top-4 left-4 flex flex-col space-y-2 z-20">
+            <div class="ui-panel p-3 rounded-lg w-64">
+                <div class="text-xs uppercase tracking-widest text-gray-400">Run Status</div>
+                <div class="flex justify-between text-sm mt-2">
+                    <span>Time Survived</span>
+                    <span id="runTimeText" class="font-semibold text-gray-100">00:00</span>
+                </div>
+                <div class="flex justify-between text-sm">
+                    <span>Villages Saved</span>
+                    <span id="runVillagesSaved" class="font-semibold text-green-300">0/3</span>
+                </div>
+                <div class="flex justify-between text-sm">
+                    <span>Villages Lost</span>
+                    <span id="runVillagesLost" class="font-semibold text-red-300">0/2</span>
+                </div>
+                <div class="mt-3">
+                    <div class="flex justify-between text-xs uppercase tracking-widest text-gray-400">
+                        <span>Castle Probe</span>
+                        <span id="castleProbeLabel" class="font-semibold text-gray-300">Calm</span>
+                    </div>
+                    <div class="h-2 rounded-sm bar-bg mt-1 overflow-hidden">
+                        <div id="castleProbeProgress" class="h-full rounded-sm" style="width: 0%;"></div>
+                    </div>
+                </div>
+                <div id="runObjectiveText" class="mt-3 text-xs text-yellow-200 text-center tracking-wide"></div>
+            </div>
+        </div>
+
         <div class="absolute top-4 right-4 flex flex-col items-end space-y-2">
             <div id="phasePanel" class="ui-panel phase-panel p-3 rounded-lg text-right">
                 <div class="text-xs uppercase tracking-widest text-gray-400">Phase</div>
@@ -58,9 +86,35 @@
 
         <div id="tooltipPanel" class="hidden absolute ui-panel p-2 rounded-md text-sm pointer-events-none z-50"></div>
 
-        <div id="gameOverScreen" class="hidden absolute inset-0 bg-black bg-opacity-75 flex flex-col justify-center items-center z-30">
-            <h2 class="font-medieval text-6xl text-red-500">You Have Perished</h2>
-            <p class="text-xl mt-4">Refresh to try again.</p>
+        <div id="gameOverScreen" class="hidden absolute inset-0 bg-black bg-opacity-75 flex flex-col justify-center items-center z-30 p-4">
+            <div class="ui-panel p-8 rounded-lg text-center w-full max-w-xl">
+                <h2 id="runSummaryTitle" class="font-medieval text-5xl text-red-400">Dominion Falls</h2>
+                <p id="runSummarySubtitle" class="text-lg mt-4 text-gray-200"></p>
+                <div class="grid grid-cols-2 gap-4 mt-6 text-left">
+                    <div>
+                        <div class="text-xs uppercase tracking-widest text-gray-400">Time Survived</div>
+                        <div id="runSummaryTime" class="text-lg font-semibold text-gray-100">00:00</div>
+                    </div>
+                    <div>
+                        <div class="text-xs uppercase tracking-widest text-gray-400">Villages Saved</div>
+                        <div id="runSummaryVillagesSaved" class="text-lg font-semibold text-green-300">0/3</div>
+                    </div>
+                    <div>
+                        <div class="text-xs uppercase tracking-widest text-gray-400">Villages Lost</div>
+                        <div id="runSummaryVillagesLost" class="text-lg font-semibold text-red-300">0/2</div>
+                    </div>
+                    <div>
+                        <div class="text-xs uppercase tracking-widest text-gray-400">Castle Probe</div>
+                        <div id="runSummaryCastleProbe" class="text-lg font-semibold text-gray-100">0%</div>
+                    </div>
+                </div>
+                <button
+                    id="runSummaryRestart"
+                    class="mt-8 px-6 py-2 bg-purple-600 hover:bg-purple-700 transition rounded-md text-white font-semibold"
+                >
+                    Play Again
+                </button>
+            </div>
         </div>
 
         <div id="draggedItemIcon" class="item-icon hidden"></div>

--- a/scripts/ai.js
+++ b/scripts/ai.js
@@ -1,6 +1,7 @@
 import { GAME_CONFIG, MILITIA_STATS, SCOUT_STATS, MINION_TYPES } from './constants.js';
 import { gameState } from './state.js';
 import { distance, isPointInRect } from './utils.js';
+import { handleHeroDefeat, registerVillageLoss, registerVillageSave } from './run-conditions.js';
 
 function getHeroCenter() {
     return {
@@ -425,7 +426,12 @@ export function updateScoutsAI(deltaTime) {
             const targetVillage = scout.targetVillageId
                 ? gameState.villages.find((village) => village.id === scout.targetVillageId)
                 : null;
-            if (targetVillage) {
+            if (targetVillage && targetVillage.hasFallen) {
+                scout.assignment = 'PATROL';
+                scout.targetVillageId = null;
+                scout.patrolCenterX = scout.x;
+                scout.patrolCenterY = scout.y;
+            } else if (targetVillage) {
                 const distToVillage = distance(targetVillage.x, targetVillage.y, scout.x, scout.y);
                 const calmVillage = !targetVillage.isUnderAttack && targetVillage.attackers.size === 0;
                 if (calmVillage && distToVillage < SCOUT_STATS.patrolRadius * 0.5) {
@@ -456,6 +462,9 @@ export function updateScoutsAI(deltaTime) {
                 scout.noiseInvestigationTimer = 0;
             } else {
                 for (const village of gameState.villages) {
+                    if (village.hasFallen) {
+                        continue;
+                    }
                     const targets =
                         scout.role === 'tank'
                             ? [...village.huts, ...village.villagers]
@@ -698,8 +707,7 @@ export function handleCollisionsAndDeaths() {
 
     if (gameState.hero.hp <= 0) {
         gameState.hero.hp = 0;
-        gameState.gameOver = true;
-        document.getElementById('gameOverScreen').classList.remove('hidden');
+        handleHeroDefeat('hero_fell');
     }
 
     for (let i = gameState.scouts.length - 1; i >= 0; i -= 1) {
@@ -711,6 +719,7 @@ export function handleCollisionsAndDeaths() {
                     if (village.attackers.size === 0 && village.isUnderAttack) {
                         village.isUnderAttack = false;
                         if (village.heroHasHelped) {
+                            registerVillageSave(village);
                             gameState.hero.gold += GAME_CONFIG.villageGoldReward;
                             gameState.worldTextEffects.push({
                                 text: 'Saved!',
@@ -754,6 +763,18 @@ export function handleCollisionsAndDeaths() {
         for (let i = village.militia.length - 1; i >= 0; i -= 1) {
             if (village.militia[i].hp <= 0) {
                 village.militia.splice(i, 1);
+            }
+        }
+
+        if (!village.hasFallen) {
+            const hutsStanding = village.huts.some((hut) => hut.hp > 0);
+            if (!hutsStanding) {
+                registerVillageLoss(village, 'structures_destroyed');
+                return;
+            }
+
+            if (village.villagers.length === 0) {
+                registerVillageLoss(village, 'villagers_slain');
             }
         }
     });

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -176,3 +176,13 @@ export const VILLAGE_COUNT = 4;
 export const HUTS_PER_VILLAGE = 3;
 export const VILLAGERS_PER_VILLAGE = 5;
 export const MILITIA_PER_VILLAGE = 2;
+
+export const RUN_OBJECTIVES = {
+    survivalMinutes: 15,
+    hardTimeLimitMinutes: 18,
+    villagesToSave: 3,
+    maxVillageLosses: 2,
+    castleProbeRadius: 220,
+    castleProbeDuration: 12,
+    castleProbeDecayRate: 0.6
+};

--- a/scripts/director.js
+++ b/scripts/director.js
@@ -32,13 +32,15 @@ function computeCooldown(patrolDeficit, redVillageCount) {
 }
 
 function pickRaidVillage(redVillages) {
+    const viableVillages = gameState.villages.filter((village) => !village.hasFallen);
+
     if (redVillages.length > 0) {
         return redVillages[Math.floor(Math.random() * redVillages.length)];
     }
-    if (gameState.villages.length === 0) {
+    if (viableVillages.length === 0) {
         return null;
     }
-    return gameState.villages[Math.floor(Math.random() * gameState.villages.length)];
+    return viableVillages[Math.floor(Math.random() * viableVillages.length)];
 }
 
 export function initializeDirector() {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -8,6 +8,7 @@ import { updateWorldTextEffects } from './effects.js';
 import { updateCamera } from './camera.js';
 import { draw } from './render.js';
 import { initializeDirector, updateDirector } from './director.js';
+import { updateRunState } from './run-conditions.js';
 
 function spawnScoutsForPhase() {
     const phase = getCurrentEncounterPhase();
@@ -94,12 +95,15 @@ function gameLoop(timestamp) {
     updateWorldTextEffects(deltaTime);
 
     updateDirector(deltaTime);
+    updateRunState(deltaTime);
 
     updateCamera();
     updateUI();
     draw();
 
-    requestAnimationFrame(gameLoop);
+    if (!gameState.gameOver) {
+        requestAnimationFrame(gameLoop);
+    }
 }
 
 function initialize() {
@@ -113,6 +117,12 @@ function initialize() {
     setupInputHandlers();
     resizeCanvas();
     window.addEventListener('resize', resizeCanvas);
+    const restartButton = document.getElementById('runSummaryRestart');
+    if (restartButton) {
+        restartButton.addEventListener('click', () => {
+            window.location.reload();
+        });
+    }
     requestAnimationFrame(gameLoop);
 }
 

--- a/scripts/run-conditions.js
+++ b/scripts/run-conditions.js
@@ -1,0 +1,213 @@
+import { gameState } from './state.js';
+import { RUN_OBJECTIVES } from './constants.js';
+
+const victoryMessages = {
+    objectives_met: 'You endured the hunt and safeguarded the frontier.'
+};
+
+const defeatMessages = {
+    hero_fell: 'Your hero fell before the Grimm onslaught.',
+    villages_lost: 'Too many villages were lost to darkness.',
+    castle_breached: 'Castle scouts slipped past the gate and doomed the realm.',
+    time_limit: 'The Grimm mustered overwhelming forces as time expired.'
+};
+
+function formatTime(totalSeconds) {
+    const seconds = Math.max(0, Math.floor(totalSeconds));
+    const minutes = Math.floor(seconds / 60)
+        .toString()
+        .padStart(2, '0');
+    const remainder = (seconds % 60).toString().padStart(2, '0');
+    return `${minutes}:${remainder}`;
+}
+
+function getOutcomeMessage(outcome, reason) {
+    if (outcome === 'victory') {
+        return victoryMessages[reason] ?? 'Victory! The dominion stands firm.';
+    }
+    return defeatMessages[reason] ?? 'Defeat. Grimm dominion grows unchecked.';
+}
+
+function updateSummaryPanel() {
+    const overlay = document.getElementById('gameOverScreen');
+    if (!overlay) {
+        return;
+    }
+
+    const title = document.getElementById('runSummaryTitle');
+    const subtitle = document.getElementById('runSummarySubtitle');
+    const timeEl = document.getElementById('runSummaryTime');
+    const savedEl = document.getElementById('runSummaryVillagesSaved');
+    const lostEl = document.getElementById('runSummaryVillagesLost');
+    const probeEl = document.getElementById('runSummaryCastleProbe');
+
+    overlay.classList.remove('hidden');
+
+    const outcome = gameState.runOutcome ?? 'defeat';
+    const reason = gameState.runOutcomeReason ?? 'hero_fell';
+
+    if (title) {
+        title.textContent = outcome === 'victory' ? 'Dominion Secured' : 'Dominion Falls';
+        title.classList.remove('text-emerald-400', 'text-red-400');
+        title.classList.add(outcome === 'victory' ? 'text-emerald-400' : 'text-red-400');
+    }
+
+    if (subtitle) {
+        subtitle.textContent = getOutcomeMessage(outcome, reason);
+    }
+
+    if (timeEl) {
+        timeEl.textContent = formatTime(gameState.elapsedTime);
+    }
+
+    if (savedEl) {
+        savedEl.textContent = `${gameState.villagesSaved}/${RUN_OBJECTIVES.villagesToSave}`;
+    }
+
+    if (lostEl) {
+        lostEl.textContent = `${gameState.villagesLost}/${RUN_OBJECTIVES.maxVillageLosses}`;
+    }
+
+    if (probeEl) {
+        const progress = Math.min(1, gameState.castleProbeTimer / RUN_OBJECTIVES.castleProbeDuration);
+        probeEl.textContent = `${Math.round(progress * 100)}%`;
+    }
+}
+
+function triggerVictory(reason) {
+    if (gameState.gameOver) {
+        return;
+    }
+    gameState.gameOver = true;
+    gameState.runOutcome = 'victory';
+    gameState.runOutcomeReason = reason;
+    updateSummaryPanel();
+}
+
+function triggerDefeat(reason) {
+    if (gameState.gameOver) {
+        return;
+    }
+    gameState.gameOver = true;
+    gameState.runOutcome = 'defeat';
+    gameState.runOutcomeReason = reason;
+    updateSummaryPanel();
+}
+
+function checkVictoryCondition() {
+    if (
+        gameState.elapsedTime >= RUN_OBJECTIVES.survivalMinutes * 60 &&
+        gameState.villagesSaved >= RUN_OBJECTIVES.villagesToSave &&
+        !gameState.gameOver
+    ) {
+        triggerVictory('objectives_met');
+    }
+}
+
+function checkHardTimeLimit() {
+    if (
+        RUN_OBJECTIVES.hardTimeLimitMinutes &&
+        gameState.elapsedTime >= RUN_OBJECTIVES.hardTimeLimitMinutes * 60 &&
+        !gameState.gameOver
+    ) {
+        triggerDefeat('time_limit');
+    }
+}
+
+function updateCastleProbe(deltaTime) {
+    if (gameState.gameOver) {
+        return;
+    }
+
+    const castleCenterX = gameState.castle.x + gameState.castle.width / 2;
+    const castleCenterY = gameState.castle.y + gameState.castle.height / 2;
+    const radiusSq = RUN_OBJECTIVES.castleProbeRadius * RUN_OBJECTIVES.castleProbeRadius;
+
+    let probing = false;
+    let closestDistSq = radiusSq;
+    let probingScoutId = null;
+
+    gameState.scouts.forEach((scout) => {
+        const dx = scout.x - castleCenterX;
+        const dy = scout.y - castleCenterY;
+        const distSq = dx * dx + dy * dy;
+        if (distSq <= radiusSq && distSq <= closestDistSq) {
+            probing = true;
+            closestDistSq = distSq;
+            probingScoutId = scout.id;
+        }
+    });
+
+    if (probing) {
+        gameState.castleProbeTimer = Math.min(
+            RUN_OBJECTIVES.castleProbeDuration,
+            gameState.castleProbeTimer + deltaTime
+        );
+        gameState.castleProbeSourceId = probingScoutId;
+        if (gameState.castleProbeTimer >= RUN_OBJECTIVES.castleProbeDuration) {
+            triggerDefeat('castle_breached');
+        }
+    } else if (gameState.castleProbeTimer > 0) {
+        gameState.castleProbeTimer = Math.max(
+            0,
+            gameState.castleProbeTimer - deltaTime * RUN_OBJECTIVES.castleProbeDecayRate
+        );
+        if (gameState.castleProbeTimer === 0) {
+            gameState.castleProbeSourceId = null;
+        }
+    }
+}
+
+export function updateRunState(deltaTime) {
+    if (gameState.gameOver) {
+        return;
+    }
+
+    gameState.elapsedTime += deltaTime;
+    updateCastleProbe(deltaTime);
+
+    if (gameState.gameOver) {
+        return;
+    }
+
+    checkVictoryCondition();
+    checkHardTimeLimit();
+}
+
+export function registerVillageSave(village) {
+    if (!village || gameState.gameOver) {
+        return;
+    }
+    village.saveCount = (village.saveCount ?? 0) + 1;
+    gameState.villagesSaved += 1;
+    checkVictoryCondition();
+}
+
+export function registerVillageLoss(village, cause = 'structures_destroyed') {
+    if (!village || village.hasFallen) {
+        return;
+    }
+
+    village.hasFallen = true;
+    village.isUnderAttack = false;
+    village.attackers.clear();
+
+    gameState.villagesLost += 1;
+
+    gameState.worldTextEffects.push({
+        text: cause === 'villagers_slain' ? 'Village Massacred!' : 'Village Razed!',
+        x: village.x,
+        y: village.y - 30,
+        color: 'rgba(255, 99, 71, 0.95)',
+        font: 'bold 26px MedievalSharp',
+        lifespan: 2.5
+    });
+
+    if (gameState.villagesLost >= RUN_OBJECTIVES.maxVillageLosses && !gameState.gameOver) {
+        triggerDefeat('villages_lost');
+    }
+}
+
+export function handleHeroDefeat(reason = 'hero_fell') {
+    triggerDefeat(reason);
+}

--- a/scripts/state.js
+++ b/scripts/state.js
@@ -35,7 +35,14 @@ export const gameState = {
     director: null,
     gameOver: false,
     noisePings: [],
-    noisePingIdCounter: 0
+    noisePingIdCounter: 0,
+    elapsedTime: 0,
+    villagesLost: 0,
+    villagesSaved: 0,
+    castleProbeTimer: 0,
+    castleProbeSourceId: null,
+    runOutcome: null,
+    runOutcomeReason: null
 };
 
 function clamp(value, min, max) {
@@ -77,7 +84,9 @@ function createVillage() {
         militia: [],
         isUnderAttack: false,
         attackers: new Set(),
-        heroHasHelped: false
+        heroHasHelped: false,
+        hasFallen: false,
+        saveCount: 0
     };
 
     for (let i = 0; i < HUTS_PER_VILLAGE; i += 1) {
@@ -137,6 +146,13 @@ export function initializeGameState(canvas) {
     gameState.director = null;
     gameState.noisePings = [];
     gameState.noisePingIdCounter = 0;
+    gameState.elapsedTime = 0;
+    gameState.villagesLost = 0;
+    gameState.villagesSaved = 0;
+    gameState.castleProbeTimer = 0;
+    gameState.castleProbeSourceId = null;
+    gameState.runOutcome = null;
+    gameState.runOutcomeReason = null;
     cloneShopItems();
 }
 

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -1,5 +1,6 @@
 import { gameState, getEncounterPhaseStatus, getDetectionThreat } from './state.js';
 import { updateShopButtons } from './shop.js';
+import { RUN_OBJECTIVES } from './constants.js';
 
 export function createInventorySlots() {
     const container = document.getElementById('inventoryPanel');
@@ -41,6 +42,15 @@ export function drawInventory() {
     }
 }
 
+function formatRunClock(totalSeconds) {
+    const seconds = Math.max(0, Math.floor(totalSeconds));
+    const minutes = Math.floor(seconds / 60)
+        .toString()
+        .padStart(2, '0');
+    const remainder = (seconds % 60).toString().padStart(2, '0');
+    return `${minutes}:${remainder}`;
+}
+
 export function updateUI() {
     const healthBar = document.getElementById('heroHealthBar');
     const healthText = document.getElementById('heroHealthText');
@@ -51,6 +61,12 @@ export function updateUI() {
     const phaseAccent = document.getElementById('phasePanel');
     const detectionFill = document.getElementById('detectionMeterFill');
     const detectionText = document.getElementById('detectionMeterText');
+    const runTimeText = document.getElementById('runTimeText');
+    const runVillagesSaved = document.getElementById('runVillagesSaved');
+    const runVillagesLost = document.getElementById('runVillagesLost');
+    const castleProbeBar = document.getElementById('castleProbeProgress');
+    const castleProbeLabel = document.getElementById('castleProbeLabel');
+    const objectiveText = document.getElementById('runObjectiveText');
 
     healthBar.style.width = `${(gameState.hero.hp / gameState.hero.maxHp) * 100}%`;
     healthText.textContent = `${Math.ceil(gameState.hero.hp)}/${Math.ceil(gameState.hero.maxHp)}`;
@@ -98,5 +114,31 @@ export function updateUI() {
         detectionText.textContent = label.toUpperCase();
         detectionText.style.color =
             clamped >= 0.8 ? '#fca5a5' : clamped >= 0.5 ? '#fde68a' : clamped > 0.25 ? '#fef08a' : '#bbf7d0';
+    }
+
+    if (runTimeText) {
+        runTimeText.textContent = formatRunClock(gameState.elapsedTime);
+    }
+
+    if (runVillagesSaved) {
+        runVillagesSaved.textContent = `${gameState.villagesSaved}/${RUN_OBJECTIVES.villagesToSave}`;
+    }
+
+    if (runVillagesLost) {
+        runVillagesLost.textContent = `${gameState.villagesLost}/${RUN_OBJECTIVES.maxVillageLosses}`;
+    }
+
+    if (castleProbeBar && castleProbeLabel) {
+        const progress = Math.min(1, gameState.castleProbeTimer / RUN_OBJECTIVES.castleProbeDuration);
+        castleProbeBar.style.width = `${progress * 100}%`;
+        castleProbeBar.style.background =
+            progress > 0 ? 'linear-gradient(90deg, #f87171, #b91c1c)' : 'linear-gradient(90deg, #22d3ee, #38bdf8)';
+        castleProbeLabel.textContent = progress > 0 ? `${Math.round(progress * 100)}%` : 'Calm';
+        castleProbeLabel.classList.toggle('text-red-300', progress > 0);
+        castleProbeLabel.classList.toggle('text-gray-300', progress === 0);
+    }
+
+    if (objectiveText) {
+        objectiveText.textContent = `Goal: Save ${RUN_OBJECTIVES.villagesToSave} villages by ${RUN_OBJECTIVES.survivalMinutes}:00`;
     }
 }


### PR DESCRIPTION
## Summary
- implement configurable run objectives and castle probe tracking to trigger win and loss states
- update AI and director logic to respect fallen villages and count player saves toward the win condition
- refresh the HUD and end-of-run overlay with status readouts and restart support

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68ded37c7be88332b2198732ce79c3dc