### PR TITLE
Rebalance early game pacing and refresh HUD

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,66 +17,75 @@
     <div id="gameContainer" class="w-full max-w-5xl mx-auto flex-grow relative rounded-lg overflow-hidden">
         <canvas id="gameCanvas"></canvas>
 
-        <div class="absolute top-4 left-4 flex flex-col space-y-2 z-20">
-            <div class="ui-panel p-3 rounded-lg w-64">
-                <div class="text-xs uppercase tracking-widest text-gray-400">Run Status</div>
-                <div class="flex justify-between text-sm mt-2">
-                    <span>Time Survived</span>
-                    <span id="runTimeText" class="font-semibold text-gray-100">00:00</span>
-                </div>
-                <div class="flex justify-between text-sm">
-                    <span>Villages Saved</span>
-                    <span id="runVillagesSaved" class="font-semibold text-green-300">0/3</span>
-                </div>
-                <div class="flex justify-between text-sm">
-                    <span>Villages Lost</span>
-                    <span id="runVillagesLost" class="font-semibold text-red-300">0/2</span>
-                </div>
-                <div class="mt-3">
-                    <div class="flex justify-between text-xs uppercase tracking-widest text-gray-400">
-                        <span>Castle Probe</span>
-                        <span id="castleProbeLabel" class="font-semibold text-gray-300">Calm</span>
+        <div id="hudOverlay" class="absolute top-4 left-1/2 -translate-x-1/2 z-20 w-[95%] max-w-4xl">
+            <div class="ui-panel p-4 rounded-xl unified-hud">
+                <div class="unified-hud-grid">
+                    <div class="hud-section space-y-3">
+                        <div class="text-xs uppercase tracking-widest text-gray-400">Run Status</div>
+                        <div class="flex justify-between text-sm">
+                            <span>Time Survived</span>
+                            <span id="runTimeText" class="font-semibold text-gray-100">00:00</span>
+                        </div>
+                        <div class="flex justify-between text-sm">
+                            <span>Villages Saved</span>
+                            <span id="runVillagesSaved" class="font-semibold text-green-300">0/3</span>
+                        </div>
+                        <div class="flex justify-between text-sm">
+                            <span>Villages Lost</span>
+                            <span id="runVillagesLost" class="font-semibold text-red-300">0/2</span>
+                        </div>
+                        <div>
+                            <div class="flex justify-between text-xs uppercase tracking-widest text-gray-400">
+                                <span>Castle Probe</span>
+                                <span id="castleProbeLabel" class="font-semibold text-gray-300">Calm</span>
+                            </div>
+                            <div class="h-2 rounded-sm bar-bg mt-1 overflow-hidden">
+                                <div id="castleProbeProgress" class="h-full rounded-sm" style="width: 0%;"></div>
+                            </div>
+                        </div>
+                        <div id="runObjectiveText" class="text-xs text-yellow-200 text-center tracking-wide"></div>
                     </div>
-                    <div class="h-2 rounded-sm bar-bg mt-1 overflow-hidden">
-                        <div id="castleProbeProgress" class="h-full rounded-sm" style="width: 0%;"></div>
-                    </div>
-                </div>
-                <div id="runObjectiveText" class="mt-3 text-xs text-yellow-200 text-center tracking-wide"></div>
-            </div>
-        </div>
 
-        <div class="absolute top-4 right-4 flex flex-col items-end space-y-2">
-            <div id="phasePanel" class="ui-panel phase-panel p-3 rounded-lg text-right">
-                <div class="text-xs uppercase tracking-widest text-gray-400">Phase</div>
-                <div id="phaseName" class="font-medieval text-2xl text-phase-accent">Calm</div>
-                <div id="phaseTimer" class="text-sm text-gray-300">00:00</div>
-            </div>
-        </div>
+                    <div class="hud-section space-y-3">
+                        <div class="text-xs uppercase tracking-widest text-gray-400">Hero Status</div>
+                        <div class="flex items-center justify-between">
+                            <span class="font-medieval text-lg text-yellow-400">Gold</span>
+                            <span id="heroGoldText" class="font-bold text-lg text-yellow-200">0</span>
+                        </div>
+                        <div>
+                            <div class="flex items-center justify-between text-sm">
+                                <span class="font-medieval text-green-400">Health</span>
+                                <span id="heroHealthText" class="font-semibold">100/100</span>
+                            </div>
+                            <div class="h-4 rounded-md bar-bg mt-1">
+                                <div id="heroHealthBar" class="h-full rounded-sm health-bar-fill"></div>
+                            </div>
+                        </div>
+                        <div>
+                            <div class="flex items-center justify-between text-sm">
+                                <span class="font-medieval text-red-300">Detection</span>
+                                <span id="detectionMeterText" class="font-bold text-xs tracking-widest text-red-200">HIDDEN</span>
+                            </div>
+                            <div class="h-3 rounded-md bar-bg mt-1">
+                                <div id="detectionMeterFill" class="h-full rounded-sm detection-bar-fill"></div>
+                            </div>
+                        </div>
+                        <div>
+                            <div class="text-xs uppercase tracking-widest text-gray-400 mb-1">Inventory</div>
+                            <div id="inventoryPanel" class="inventory-grid"></div>
+                        </div>
+                    </div>
 
-        <div class="absolute bottom-4 left-4 flex items-end space-x-2">
-            <div class="ui-panel p-2 rounded-lg flex flex-col space-y-2" style="width: 250px;">
-                <div class="flex items-center space-x-2 w-full">
-                    <span class="font-medieval text-lg text-yellow-400">Gold</span>
-                    <span id="heroGoldText" class="font-bold text-lg flex-grow text-yellow-200 text-center">0</span>
-                </div>
-                <div class="flex items-center space-x-2 w-full">
-                    <span class="font-medieval text-lg text-green-400">Health</span>
-                    <div class="flex-grow h-4 rounded-md bar-bg">
-                        <div id="heroHealthBar" class="h-full rounded-sm health-bar-fill"></div>
+                    <div id="phasePanel" class="hud-section phase-panel text-right space-y-2">
+                        <div class="text-xs uppercase tracking-widest text-gray-400">Phase</div>
+                        <div id="phaseName" class="font-medieval text-2xl text-phase-accent">Calm</div>
+                        <div id="phaseTimer" class="text-sm text-gray-300">00:00</div>
+                        <div class="text-xs text-gray-400 leading-relaxed">
+                            Maintain stealth while the dominion gathers strength.
+                        </div>
                     </div>
-                    <span id="heroHealthText" class="font-bold text-sm w-24 text-center">100/100</span>
-                </div>
-                <div class="flex items-center space-x-2 w-full">
-                    <span class="font-medieval text-lg text-red-300">Detection</span>
-                    <div class="flex-grow h-3 rounded-md bar-bg">
-                        <div id="detectionMeterFill" class="h-full rounded-sm detection-bar-fill"></div>
-                    </div>
-                    <span id="detectionMeterText" class="font-bold text-xs w-24 text-center tracking-widest text-red-200">
-                        HIDDEN
-                    </span>
                 </div>
             </div>
-            <div id="inventoryPanel" class="ui-panel p-2 rounded-lg grid grid-cols-6 gap-2"></div>
         </div>
 
         <div id="shopPanel" class="hidden absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 ui-panel p-4 rounded-lg w-96 z-20">

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -10,7 +10,7 @@ export const GAME_CONFIG = {
 
 export const DIRECTOR_CONFIG = {
     targetPatrolCount: 6,
-    initialPatrolCount: 4,
+    initialPatrolCount: 0,
     spawnCost: 3,
     startingEnergy: 6,
     maxEnergy: 24,
@@ -26,7 +26,7 @@ export const DIRECTOR_CONFIG = {
     baseRaidWeight: 0.55,
     multiVillageRaidMultiplier: 2.2,
     maxBatchSpawns: 3,
-    initialDelay: 3.5
+    initialDelay: 2.5
 };
 
 export const HERO_BASE_STATS = {

--- a/scripts/director.js
+++ b/scripts/director.js
@@ -53,10 +53,6 @@ export function initializeDirector() {
     };
 
     gameState.spawnTimer = 0;
-
-    for (let i = 0; i < DIRECTOR_CONFIG.initialPatrolCount; i += 1) {
-        gameState.scouts.push(createScout({ assignment: 'PATROL' }));
-    }
 }
 
 export function updateDirector(deltaTime) {

--- a/scripts/render.js
+++ b/scripts/render.js
@@ -103,24 +103,15 @@ export function draw() {
     gameState.scouts.forEach((scout) => {
         const detectionRatio = Math.max(0, Math.min(1, scout.detectionLevel ?? 0));
         const shouldShowCone = scout.state !== 'ATTACKING_VILLAGE';
-        if (shouldShowCone && scout.sightRange && scout.visionCone) {
-            const coneMultiplier = scout.state === 'CHASING' ? 1.2 : 1;
-            const halfCone = (scout.visionCone * coneMultiplier) / 2;
+        if (shouldShowCone && scout.sightRange) {
             ctx.beginPath();
-            ctx.moveTo(scout.x, scout.y);
-            ctx.arc(
-                scout.x,
-                scout.y,
-                scout.sightRange,
-                (scout.facingAngle ?? 0) - halfCone,
-                (scout.facingAngle ?? 0) + halfCone
-            );
-            ctx.closePath();
-            ctx.fillStyle = `rgba(255, 255, 120, ${0.05 + detectionRatio * 0.25})`;
-            ctx.fill();
+            ctx.arc(scout.x, scout.y, scout.sightRange, 0, Math.PI * 2);
+            ctx.strokeStyle = `rgba(255, 255, 170, ${0.02 + detectionRatio * 0.08})`;
+            ctx.lineWidth = 2;
+            ctx.stroke();
             ctx.beginPath();
             ctx.arc(scout.x, scout.y, scout.criticalSightRange, 0, Math.PI * 2);
-            ctx.fillStyle = `rgba(255, 120, 120, ${0.08 + detectionRatio * 0.3})`;
+            ctx.fillStyle = `rgba(255, 140, 140, ${0.04 + detectionRatio * 0.12})`;
             ctx.fill();
         }
         if (scout.role === 'priest' && scout.healRadius) {

--- a/scripts/state.js
+++ b/scripts/state.js
@@ -116,8 +116,42 @@ function createForest() {
 }
 
 function createVillage() {
-    const baseX = (Math.random() > 0.5 ? 0.25 : 0.75) * WORLD.width + (Math.random() - 0.5) * 500;
-    const baseY = (Math.random() > 0.5 ? 0.25 : 0.75) * WORLD.height + (Math.random() - 0.5) * 500;
+    const castleCenterX = CASTLE.x + CASTLE.width / 2;
+    const castleCenterY = CASTLE.y + CASTLE.height / 2;
+    const minDistanceFromCastle = Math.max(CASTLE.width, CASTLE.height) * 6;
+
+    let baseX = castleCenterX;
+    let baseY = castleCenterY;
+    let attempts = 0;
+
+    while (attempts < 8) {
+        const horizontalAnchor = Math.random() < 0.5 ? 0.15 : 0.85;
+        const verticalAnchor = Math.random() < 0.5 ? 0.2 : 0.8;
+        baseX = clamp(WORLD.width * horizontalAnchor + (Math.random() - 0.5) * 220, 120, WORLD.width - 120);
+        baseY = clamp(WORLD.height * verticalAnchor + (Math.random() - 0.5) * 220, 120, WORLD.height - 120);
+
+        const distanceToCastle = Math.hypot(baseX - castleCenterX, baseY - castleCenterY);
+        if (distanceToCastle >= minDistanceFromCastle) {
+            break;
+        }
+        attempts += 1;
+    }
+
+    const finalDistance = Math.hypot(baseX - castleCenterX, baseY - castleCenterY);
+    if (finalDistance < minDistanceFromCastle) {
+        const directionAngle = Math.atan2(baseY - castleCenterY, baseX - castleCenterX) + (Math.random() - 0.5) * 0.6;
+        baseX = clamp(
+            castleCenterX + Math.cos(directionAngle) * minDistanceFromCastle,
+            120,
+            WORLD.width - 120
+        );
+        baseY = clamp(
+            castleCenterY + Math.sin(directionAngle) * minDistanceFromCastle,
+            120,
+            WORLD.height - 120
+        );
+    }
+
     const village = {
         id: Math.random(),
         x: baseX,

--- a/styles/main.css
+++ b/styles/main.css
@@ -23,6 +23,51 @@ canvas {
     box-shadow: 0 0 15px rgba(0, 0, 0, 0.8);
 }
 
+.unified-hud {
+    backdrop-filter: blur(6px);
+}
+
+.unified-hud-grid {
+    display: grid;
+    gap: 1.25rem;
+}
+
+@media (min-width: 640px) {
+    .unified-hud-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (min-width: 960px) {
+    .unified-hud-grid {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+}
+
+.hud-section {
+    background-color: rgba(20, 16, 12, 0.65);
+    border: 1px solid rgba(90, 61, 43, 0.65);
+    border-radius: 0.75rem;
+    padding: 1rem;
+    box-shadow: inset 0 0 12px rgba(0, 0, 0, 0.45);
+}
+
+.inventory-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.5rem;
+    background-color: rgba(26, 16, 8, 0.7);
+    border: 1px solid #7a5c4b;
+    padding: 0.5rem;
+    border-radius: 0.5rem;
+}
+
+@media (min-width: 640px) {
+    .inventory-grid {
+        grid-template-columns: repeat(6, minmax(0, 1fr));
+    }
+}
+
 .bar-bg {
     background-color: #333;
     border: 1px solid #7a5c4b;


### PR DESCRIPTION
## Summary
- prevent scouts from spawning at game start and shorten the castle's first cooldown
- push villages farther from the castle and tone down enemy vision indicators
- consolidate the HUD into a single overlay with refreshed styling and integrated inventory

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dede9605008332a60c50ff0a186aa2