### PR TITLE
Add vertical slice prototype documentation

### DIFF
--- a/docs/prototype/README.md
+++ b/docs/prototype/README.md
@@ -1,0 +1,12 @@
+# Grimm Dominion Vertical Slice Prototype
+
+This document organizes the scope required to build the Grimm Dominion vertical slice described in the primary design documentation. It focuses on the first public-facing playable that proves the asymmetric 1v4 experience.
+
+- [Vision & Success Criteria](vision.md)
+- [Playable Roles](roles.md)
+- [Core Systems](systems.md)
+- [World & Content](world.md)
+- [UX & Controls](ux.md)
+- [Art & Audio](art_audio.md)
+- [Technology & Infrastructure](technology.md)
+- [Production Roadmap](roadmap.md)

--- a/docs/prototype/art_audio.md
+++ b/docs/prototype/art_audio.md
@@ -1,0 +1,33 @@
+# Art & Audio Direction
+
+## Visual Targets
+- **Style:** Cartoony-gothic with exaggerated silhouettes and saturated accents inspired by storybook illustrations.
+- **Characters:**
+  - Dark Lord: Ornate armor, elongated proportions, cape with animated shadow tendrils.
+  - Exiled Knight: Heavy armor with scorched heraldry, glowing valor sigil on shield.
+  - Goblin Outlaw: Patchwork leather, jingling coin bags, oversized goggles.
+- **Environments:** Modular biome kits with re-usable props (gnarled trees, crooked houses, rune stones). Shared texture atlas for performance.
+- **UI:** Storybook frames with parchment textures, bold iconography for readability on mobile.
+
+## Animation Priorities
+- Hero locomotion blends (idle, jog, sprint) with additive combat swings.
+- Dark Lord spellcasting loops for ritual node interactions.
+- Minion behavior specific idles and alerts to telegraph AI state.
+- Gate destruction stages with debris FX.
+
+## VFX & Lighting
+- Foggy volumetrics around castle, contrasting warm lighting near villages.
+- Ability FX to reinforce gameplay clarity (e.g., Smoke Bomb opacity drop, Valor Surge aura).
+- Low-poly particle systems tuned for mobile budgets; LOD swaps beyond 30m camera distance.
+
+## Audio Pillars
+- **Music:** Layered tracks that intensify as match escalates; bossy organ motifs during late-game assaults.
+- **SFX:**
+  - Goblin gold jingle, Knight shield clang, minion spawn whoosh.
+  - UI sounds for alerts, pings, and resource gains.
+- **VO:** Limited taunts for Dark Lord, hero exertions, contextual callouts for critical events.
+
+## Technical Requirements
+- Use FMOD middleware for adaptive music layers.
+- Implement audio occlusion and distance falloff for spatial awareness.
+- Budget: <40MB total audio footprint for mobile builds.

--- a/docs/prototype/roadmap.md
+++ b/docs/prototype/roadmap.md
@@ -1,0 +1,37 @@
+# Production Roadmap
+
+## Milestone 1 – Core Loop Sprint (6 Weeks)
+**Objectives:** Establish base gameplay and networking.
+- Implement Dark Lord vs. Exiled Knight on greybox map.
+- Integrate Evil Energy, Valor, and Gold resource flows.
+- Build AI minion archetypes with baseline behaviors.
+- Stand up Photon Fusion room creation and reconnection.
+- Create developer UI for debugging vision/noise systems.
+
+**Exit Criteria:** Internal playtest completes full match with basic UI, no art polish.
+
+## Milestone 2 – Economy & Content Sprint (5 Weeks)
+**Objectives:** Expand hero roster and world variety.
+- Add Goblin Outlaw hero, tavern economy, and stealth loop.
+- Implement procedural chunk assembly with three biome variants.
+- Script Knight quests and Goblin gold events.
+- Add castle gate destruction/repair mechanics.
+- Integrate telemetry logging for match metrics.
+
+**Exit Criteria:** Heroes demonstrate distinct playstyles; Dark Lord pressure sustained; telemetry dashboards populated.
+
+## Milestone 3 – Polish & Presentation Sprint (4 Weeks)
+**Objectives:** Elevate visuals, audio, and user readiness.
+- Apply art pass to heroes, minions, and key environments.
+- Implement HUD skins, minimap pings, and contextual prompts.
+- Add core SFX/VFX beats and adaptive music layers.
+- Introduce matchmaking stub UI and post-match progression summary.
+- Conduct performance optimization and network soak tests.
+
+**Exit Criteria:** Vertical slice ready for stakeholder demo, hitting performance targets and feature completeness.
+
+## Post-Slice Backlog
+- Forest Witch hero prototype.
+- Additional map chunks and random events.
+- Live-ops hooks: cosmetic storefront, seasonal battle pass planning.
+- Ranked matchmaking design exploration.

--- a/docs/prototype/roles.md
+++ b/docs/prototype/roles.md
@@ -1,0 +1,28 @@
+# Playable Roles
+
+## Dark Lord (Commander)
+- **Primary Loop:** Accumulate Evil Energy from castle nodes, spend on summoning minions (scouts, tanks, priests), and cast situational spells to track and pressure heroes.
+- **Key Abilities:**
+  - *Summon Minion Portal:* Spawn AI-controlled units at unlocked spawn pads.
+  - *Shadow Pulse:* Global ping revealing noisy hero actions for 3 seconds.
+  - *Castle Fortify:* Temporarily buffs gate HP and tower damage.
+- **UI Needs:** Overhead tactical camera, unit roster panel, ability bar with cooldowns, alert log.
+
+## Exiled Knight (Hero)
+- **Primary Loop:** Complete valor quests (rescue villagers, retrieve artifacts) to earn Valor points that unlock defensive abilities and gear upgrades.
+- **Key Abilities:**
+  - *Shield Bash:* Short stun for minion disruption.
+  - *Bulwark Ward:* Deployable barrier that blocks projectiles for 8 seconds.
+  - *Valor Surge:* Spend Valor to empower allies within a small radius.
+- **UI Needs:** Third-person movement stick, ability buttons, valor tracker, quest log widget.
+
+## Goblin Outlaw (Hero)
+- **Primary Loop:** Stealth around the map looting gold caches, returning to the hidden tavern to purchase black market upgrades.
+- **Key Abilities:**
+  - *Smoke Bomb:* Creates a temporary vision-blocking field and breaks line of sight.
+  - *Sneak Strike:* Bonus damage when attacking from stealth.
+  - *Greedy Stash:* Bank gold mid-field at a risky drop point.
+- **UI Needs:** Stealth indicator, noise meter, gold counter, upgrade radial at tavern.
+
+## Future Expansion: Forest Witch (Deferred)
+Documented requirements for channeling rituals, debuffs, and area denial remain in the source design doc but are out of scope for the slice. Minimal prototyping will occur only after the first vertical slice evaluation.

--- a/docs/prototype/systems.md
+++ b/docs/prototype/systems.md
@@ -1,0 +1,24 @@
+# Core Systems
+
+## Shared Stealth & Detection
+- **Fog of War:** Server maintains authoritative visibility. Heroes see in a 120° cone with 25m radius, Dark Lord sees via minion vision and castle sensors.
+- **Noise Events:** Movement, combat, and interactions emit noise signatures stored for 5 seconds. Dark Lord receives pings based on minion proximity and active Shadow Pulse.
+- **Disguises & Deception:** Goblin can disguise as villagers when stationary; detection requires minion inspection within 5m.
+
+## Resource Economies
+- **Evil Energy:** Passive trickle plus bonus from captured shrines. Spent on unit spawns (cost scaling by tier) and spells. Cap at 100 to encourage spending.
+- **Valor:** Quest completions grant 1–3 Valor; used to unlock Knight abilities and consumables at campfires.
+- **Gold:** Goblin collects from caches (5–15 each) and chest events; spent at tavern for stat boosts and utility items.
+
+## AI Minions
+- **Archetypes:**
+  - *Scout Imp:* Fast, low damage, high vision. Patrol paths and report sightings.
+  - *Bonecrusher:* Tanky melee unit with gate-guard behavior. Reacts to pings by converging.
+  - *Hex Priest:* Ranged support that channels debuffs, vulnerable when interrupted.
+- **Behavior Trees:** Authored in Unity using scriptable nodes. Server sends intention packets; clients simulate for responsiveness with reconciliation.
+- **Escalation Rules:** Unlock stronger minion waves at 5 and 10-minute marks, triggered by castle energy thresholds.
+
+## Combat & Progression
+- **Hero Downed State:** Heroes fall into a 20-second revival window. Dark Lord can execute via spell; allies can revive with channel.
+- **Damage Model:** Light action combat with cooldown abilities, no friendly fire. Armor types (cloth, leather, plate) interact with minion damage modifiers.
+- **Progression Hooks:** Track match XP and account progression for post-match screens; placeholder UI suffices.

--- a/docs/prototype/technology.md
+++ b/docs/prototype/technology.md
@@ -1,0 +1,27 @@
+# Technology & Infrastructure
+
+## Engine & Platform
+- Unity 2022 LTS with URP for mobile optimization.
+- Photon Fusion for authoritative server-hosted simulation with client prediction.
+- Target platforms: Android (OpenGL ES 3.0) and iOS (Metal).
+
+## Architecture Overview
+- **Server Authoritative:** Dedicated host handles AI, Fog of War, resource management, and match state. Clients run prediction for movement and ability execution.
+- **Networking:** Tick rate 20Hz, delta compression on state updates, reliable RPCs reserved for objective triggers.
+- **Procedural Generation:** Chunk selection seeded from match ID, server builds navmesh and transmits chunk metadata to clients on load.
+
+## Tooling & Pipelines
+- ScriptableObject-based data definitions for units, abilities, quests.
+- Behavior Designer (or custom node editor) for minion behavior trees.
+- Addressables for streaming art assets and patching content without full client updates.
+- CI pipeline via GitHub Actions building Android/iOS dev builds nightly, running unit tests and integration smoke tests.
+
+## Telemetry & Analytics
+- Capture match length, role selection, win/loss, resource income rates, and objective completion times.
+- Use Unity Analytics or custom lightweight pipeline posting JSON to AWS API Gateway.
+- Privacy compliant; collect no PII, only anonymized session IDs.
+
+## QA & Testing
+- Automated play mode tests for resource accrual, quest completion, and AI state transitions.
+- Performance capture harness to log FPS, memory, and CPU usage during scripted scenarios.
+- Network soak tests with bots simulating hero actions to validate stability.

--- a/docs/prototype/ux.md
+++ b/docs/prototype/ux.md
@@ -1,0 +1,23 @@
+# UX & Controls
+
+## Hero Client
+- **Input:** Virtual joystick for movement, single attack button, three ability buttons with radial cooldowns, interact button that contextually changes (revive, loot, deliver).
+- **HUD:**
+  - Resource widget left of abilities showing Valor or Gold.
+  - Minimap in top-right with ping functionality (tap to ping, hold to select alert type).
+  - Quest tracker vertical stack on left with icons and progress bars.
+  - Downed teammate indicators at screen edge.
+- **Accessibility:** Toggle for high-contrast ability outlines, aim assist for ranged attacks, and vibration feedback on incoming damage.
+
+## Dark Lord Client
+- **Input:** Drag-to-pan overhead camera, pinch zoom, tap to select spawn pads, and ability hotkeys.
+- **HUD:**
+  - Minion roster listing available archetypes with cooldown wheels.
+  - Evil Energy bar with spend history tooltip.
+  - Alert feed that surfaces noise events, objectives, and minion deaths.
+  - Tactical map overlay triggered by two-finger tap showing Fog of War and minion patrol paths.
+
+## Communication
+- **Ping System:** Shared radial with attack/defend/assist/loot options, contextually placed on minimap.
+- **Quick Chat:** Predefined phrases (“Gate under attack”, “Need Valor quest”, “Dark Lord spotted”) accessible via swipe menu.
+- **Tutorial Prompts:** Contextual pop-ups for first match guiding resource loops and stealth mechanics.

--- a/docs/prototype/vision.md
+++ b/docs/prototype/vision.md
@@ -1,0 +1,17 @@
+# Vision & Success Criteria
+
+## Prototype Goal
+Deliver a 15-minute match vertical slice that validates the cat-and-mouse tension between a single Dark Lord and two distinct heroes (Exiled Knight and Goblin Outlaw) across a procedurally assembled map. The prototype must demonstrate the core asymmetric RTS fantasy with touch-friendly controls.
+
+## Success Metrics
+- **Engagement:** 70% of internal playtesters voluntarily request a second match within the same session.
+- **Match Flow:** Average match duration stays between 13–17 minutes with observable early, mid, and late-game beats.
+- **Asymmetry Validation:** Playtest feedback indicates both heroes feel meaningfully different while the Dark Lord can exert pressure without direct control.
+- **Technical Stability:** 95% of sessions complete without desynchronization or game-breaking bugs on target mid-tier mobile hardware.
+- **Performance:** Frame rate remains at or above 30 FPS on reference Android (Snapdragon 765) and iOS (A12) devices during large skirmishes.
+
+## Scope Guardrails
+- Limit hero roster to the Exiled Knight and Goblin Outlaw; the Forest Witch is reserved for a later iteration.
+- Restrict castle defenses to one breakable gate, one tower type, and one ritual node to accelerate content creation.
+- Author three biome chunks (village, shrine, forest) that can be recombined to simulate procedural variety without overproducing art.
+- Deliver only stub matchmaking and monetization flows; focus on the gameplay loop and telemetry capture.

--- a/docs/prototype/world.md
+++ b/docs/prototype/world.md
@@ -1,0 +1,26 @@
+# World & Content Scope
+
+## Map Structure
+- **Size:** Approximately 800m x 800m with castle hub centered on northern plateau.
+- **Chunks:**
+  - *Haunted Village:* Contains villagers to rescue, gold caches, and a chapel for Knight questline.
+  - *Ancient Shrine:* Provides Evil Energy boost when controlled; doubles as Witch ritual placeholder.
+  - *Shadowed Forest:* Dense cover for Goblin stealth, includes patrol routes and hidden caches.
+- **Dynamic Assembly:** Procedural system selects chunk variants (A/B/C) per biome, connects via paths, and seeds interactables.
+
+## Objectives & Events
+- **Knight Quests:**
+  1. *Rescue Villagers:* Escort 3 villagers to campfires for Valor.
+  2. *Retrieve Relic:* Loot from shrine, deliver to castle breach for siege aid.
+  3. *Defend the Gate:* Reactive quest triggered once castle gate is breached to encourage teamwork.
+- **Goblin Economy Routes:**
+  - Gold caches spawn in high-risk zones; moving them triggers noise events.
+  - Tavern upgrades include Smoke Bomb cooldown reduction, movement speed boots, and noise dampening charm.
+- **Random Events:**
+  - Patrol ambush spawns.
+  - Tavern rumor reveals partial hero locations or Dark Lord rituals.
+
+## Castle Setup
+- **Gate:** Single destructible gate with 3,000 HP. Repairable by Dark Lord at high energy cost.
+- **Towers:** One ranged tower covering the gate approach with upgrade path for fire arrows.
+- **Ritual Node:** Optional channel for Dark Lord to trigger late-game storm; exposes him for 10 seconds.


### PR DESCRIPTION
## Summary
- add a documentation hub under docs/prototype for the Grimm Dominion vertical slice
- describe the vision, roles, systems, world content, UX, art/audio, technology, and production roadmap for the prototype

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e3ae11726c8332b309bdb073deb1d7