### PR TITLE
Add Codespaces devcontainer for Unity setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+  "name": "Grimm Dominion Unity Codespace",
+  "image": "ghcr.io/game-ci/unity3d:ubuntu-2022.3.21f1-base-3.0",
+  "features": {
+    "ghcr.io/devcontainers/features/git-lfs:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "mounts": [
+    "source=${localEnv:HOME}/.gitconfig,target=/home/vscode/.gitconfig,type=bind,consistency=cached"
+  ],
+  "remoteEnv": {
+    "UNITY_VERSION": "2022.3.21f1"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-dotnettools.csharp",
+        "visualstudiotoolsforunity.vstuc",
+        "unity.unity-debug",
+        "github.vscode-github-actions"
+      ]
+    }
+  },
+  "postCreateCommand": ".devcontainer/scripts/post-create.sh"
+}

--- a/.devcontainer/scripts/post-create.sh
+++ b/.devcontainer/scripts/post-create.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="/workspaces/GrimmDominion"
+UNITY_LICENSE_DIR="${HOME}/.local/share/unity3d/Unity"
+PHOTON_REGISTRY="https://package.registry.photonengine.com"
+
+if [[ -d /workspaces ]]; then
+  git config --global --add safe.directory "$REPO_DIR"
+fi
+
+git lfs install --local
+if git lfs env >/dev/null 2>&1; then
+  git lfs fetch --all || true
+  git lfs checkout || true
+fi
+
+if [[ -n "${PHOTON_UPM_TOKEN:-}" ]]; then
+  mkdir -p "${HOME}/.upm"
+  cat > "${HOME}/.upm/upmconfig.toml" <<TOML
+[npmAuth."${PHOTON_REGISTRY}"]
+token = "${PHOTON_UPM_TOKEN}"
+alwaysAuth = true
+TOML
+fi
+
+if [[ -n "${UNITY_LICENSE_CONTENT:-}" ]]; then
+  mkdir -p "${UNITY_LICENSE_DIR}"
+  echo "${UNITY_LICENSE_CONTENT}" > "${UNITY_LICENSE_DIR}/Unity_lic.ulf"
+  chmod 600 "${UNITY_LICENSE_DIR}/Unity_lic.ulf"
+fi
+
+if [[ -n "${UNITY_SERIAL:-}" ]]; then
+  cat > "${REPO_DIR}/.codespace-unity-env.example" <<ENV
+UNITY_SERIAL=${UNITY_SERIAL}
+UNITY_EMAIL=${UNITY_EMAIL:-}
+UNITY_PASSWORD=${UNITY_PASSWORD:-}
+ENV
+fi
+
+echo "Codespace setup complete. Review docs/prototype/technology.md for workflow details."

--- a/docs/prototype/technology.md
+++ b/docs/prototype/technology.md
@@ -16,6 +16,23 @@
 - Addressables for streaming art assets and patching content without full client updates.
 - CI pipeline via GitHub Actions building Android/iOS dev builds nightly, running unit tests and integration smoke tests.
 
+## Codespaces Environment
+- Launch the repository in GitHub Codespaces using the provided `.devcontainer` definition, which
+  pulls the `ghcr.io/game-ci/unity3d:ubuntu-2022.3.21f1-base-3.0` image so the Unity 2022.3.21f1
+  editor and URP toolchain match the project baseline. The container installs the C# and Unity
+  debugger extensions and configures the workspace as a trusted Git directory.
+- On first boot the `post-create.sh` hook enables Git LFS, fetches tracked assets, and (when a
+  `PHOTON_UPM_TOKEN` secret is provided) writes `~/.upm/upmconfig.toml` so Unity can authenticate to
+  the Photon scoped registry for `com.photon.fusion.stub`.
+- Supply Unity license credentials as Codespaces secrets—either set `UNITY_LICENSE_CONTENT` with the
+  serialized `.ulf` text or provide `UNITY_SERIAL`, `UNITY_EMAIL`, and `UNITY_PASSWORD` so the script
+  can emit `.codespace-unity-env.example` for manual activation. The resulting license is stored
+  under `${HOME}/.local/share/unity3d/Unity/Unity_lic.ulf`.
+- Mirror CI operations locally by running the same batch mode commands outlined in the GitHub
+  Actions workflow (e.g., edit mode tests and Addressables builds) after `post-create` completes.
+  Environment variables such as `UNITY_LICENSE_CONTENT`, `UNITY_SERIAL`, and `PHOTON_UPM_TOKEN`
+  persist across terminals inside the Codespace, enabling headless builds.
+
 ## Telemetry & Analytics
 - Capture match length, role selection, win/loss, resource income rates, and objective completion times.
 - Use Unity Analytics or custom lightweight pipeline posting JSON to AWS API Gateway.


### PR DESCRIPTION
## Summary
- add a GitHub Codespaces devcontainer based on the Unity 2022.3.21f1 image with Git LFS and editor tooling
- configure post-create automation to hydrate LFS assets, set Photon registry auth, and install Unity license material when provided
- document the Codespaces workflow expectations in the technology guide

## Testing
- not run (configuration/documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e3c07ff45883328800a87286c229a7