### PR TITLE
Add Phaser browser prototype scaffold

### DIFF
--- a/docs/prototype/technology.md
+++ b/docs/prototype/technology.md
@@ -1,44 +1,52 @@
 # Technology & Infrastructure
 
 ## Engine & Platform
-- Unity 2022 LTS with URP for mobile optimization.
-- Photon Fusion for authoritative server-hosted simulation with client prediction.
-- Target platforms: Android (OpenGL ES 3.0) and iOS (Metal).
+- Browser-first vertical slice built with Phaser 3 and TypeScript, compiled with Vite for modern
+  bundling and hot module replacement.
+- WebGL 2 is the primary rendering backend, with Canvas fallback for lower powered devices.
+- Target platforms: desktop browsers (Chrome, Firefox, Edge, Safari) with responsive layout support
+  for tablets.
 
 ## Architecture Overview
-- **Server Authoritative:** Dedicated host handles AI, Fog of War, resource management, and match state. Clients run prediction for movement and ability execution.
-- **Networking:** Tick rate 20Hz, delta compression on state updates, reliable RPCs reserved for objective triggers.
-- **Procedural Generation:** Chunk selection seeded from match ID, server builds navmesh and transmits chunk metadata to clients on load.
+- **Client-Simulated, Server-Optional:** All core gameplay systems run client-side to streamline the
+  prototype. Networking hooks are abstracted through a lightweight service layer so future
+  multiplayer can slot in without rewriting scene logic.
+- **State Management:** Phaser scenes coordinate gameplay state via a central `GameStore` module that
+  tracks objectives, stealth values, and resource ticks. Deterministic update loops make future
+  lockstep or rollback netcode viable.
+- **Content Pipelines:** Narrative beats, enemy loadouts, and quest templates live as JSON data files
+  under `web/content/`. Phaser data loaders ingest the files at boot so designers can iterate without
+  code changes.
 
 ## Tooling & Pipelines
-- ScriptableObject-based data definitions for units, abilities, quests.
-- Behavior Designer (or custom node editor) for minion behavior trees.
-- Addressables for streaming art assets and patching content without full client updates.
-- CI pipeline via GitHub Actions building Android/iOS dev builds nightly, running unit tests and integration smoke tests.
+- TypeScript-first workflow with ESLint and Prettier enforcing code quality and formatting.
+- Vite dev server exposes the slice on port `5173` with hot reload, enabling rapid iteration in
+  Codespaces and local environments.
+- GitHub Actions matrix builds run `npm run lint`, `npm run test`, and `npm run build` to guarantee
+  deterministic production bundles.
+- Static assets (sprites, audio, shaders) live under `web/public/` and are referenced through Vite's
+  asset pipeline for hashed production filenames.
 
 ## Codespaces Environment
-- Launch the repository in GitHub Codespaces using the provided `.devcontainer` definition, which
-  pulls the `ghcr.io/game-ci/unity3d:ubuntu-2022.3.21f1-base-3.0` image so the Unity 2022.3.21f1
-  editor and URP toolchain match the project baseline. The container installs the C# and Unity
-  debugger extensions and configures the workspace as a trusted Git directory.
-- On first boot the `post-create.sh` hook enables Git LFS, fetches tracked assets, and (when a
-  `PHOTON_UPM_TOKEN` secret is provided) writes `~/.upm/upmconfig.toml` so Unity can authenticate to
-  the Photon scoped registry for `com.photon.fusion.stub`.
-- Supply Unity license credentials as Codespaces secrets—either set `UNITY_LICENSE_CONTENT` with the
-  serialized `.ulf` text or provide `UNITY_SERIAL`, `UNITY_EMAIL`, and `UNITY_PASSWORD` so the script
-  can emit `.codespace-unity-env.example` for manual activation. The resulting license is stored
-  under `${HOME}/.local/share/unity3d/Unity/Unity_lic.ulf`.
-- Mirror CI operations locally by running the same batch mode commands outlined in the GitHub
-  Actions workflow (e.g., edit mode tests and Addressables builds) after `post-create` completes.
-  Environment variables such as `UNITY_LICENSE_CONTENT`, `UNITY_SERIAL`, and `PHOTON_UPM_TOKEN`
-  persist across terminals inside the Codespace, enabling headless builds.
+- Launch the repository in GitHub Codespaces and run `npm install --prefix web` to pull down Phaser,
+  TypeScript, Vite, and linting dependencies.
+- Start development with `npm run dev --prefix web -- --host 0.0.0.0 --port 5173` so the Vite server
+  binds to all interfaces, making it accessible through the Codespaces forwarded port UI.
+- Use `npm run build --prefix web` to generate the production bundle under `web/dist/`. Serve the
+  output via `npm run preview --prefix web` or any static host for validation.
+- Environment variables for future backend integration are stored in `.env.local` (ignored by Git).
+  The client reads them through Vite's `import.meta.env` bridge.
 
 ## Telemetry & Analytics
-- Capture match length, role selection, win/loss, resource income rates, and objective completion times.
-- Use Unity Analytics or custom lightweight pipeline posting JSON to AWS API Gateway.
-- Privacy compliant; collect no PII, only anonymized session IDs.
+- Lightweight telemetry stub posts session summaries (role played, victory state, time-to-complete,
+  optional feedback text) to a configurable webhook endpoint.
+- Privacy compliant; the browser build stores only anonymized UUIDs in `localStorage` for session
+  stitching.
 
 ## QA & Testing
-- Automated play mode tests for resource accrual, quest completion, and AI state transitions.
-- Performance capture harness to log FPS, memory, and CPU usage during scripted scenarios.
-- Network soak tests with bots simulating hero actions to validate stability.
+- Jest runs unit tests for deterministic gameplay math, resource tick cadence, and stealth detection
+  thresholds.
+- Playwright (planned follow-up) will drive scripted hero/dark-lord flows in headless Chromium for
+  regression coverage.
+- Performance budgets: maintain 60 FPS on a 4-core Codespaces VM with Chrome, logging frame metrics
+  via the browser devtools performance API.

--- a/web/.eslintrc.cjs
+++ b/web/.eslintrc.cjs
@@ -1,0 +1,25 @@
+module.exports = {
+  root: true,
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    ecmaVersion: "latest",
+    sourceType: "module"
+  },
+  plugins: ["@typescript-eslint", "import"],
+  extends: [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:import/recommended",
+    "plugin:import/typescript",
+    "prettier"
+  ],
+  rules: {
+    "import/order": [
+      "warn",
+      {
+        "groups": [["builtin", "external"], ["internal"], ["parent", "sibling", "index"]],
+        "newlines-between": "always"
+      }
+    ]
+  }
+};

--- a/web/.prettierrc
+++ b/web/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": false,
+  "trailingComma": "all",
+  "printWidth": 100
+}

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,34 @@
+# Grimm Dominion Browser Prototype
+
+This folder contains the browser-based vertical slice for Grimm Dominion. It replaces the Unity
+prototype so the experience can run directly inside GitHub Codespaces or any modern browser.
+
+## Getting Started
+1. Install dependencies:
+   ```bash
+   npm install --prefix web
+   ```
+2. Launch the Vite dev server (Codespaces requires binding to all interfaces):
+   ```bash
+   npm run dev --prefix web -- --host 0.0.0.0 --port 5173
+   ```
+3. Open the forwarded port in the browser to view the slice. The prototype bootstraps a Phaser scene
+   that renders the overworld layout and quest deck from JSON content files.
+
+## Scripts
+- `npm run dev --prefix web` – Start the development server with hot reload.
+- `npm run build --prefix web` – Produce an optimized production bundle under `web/dist/`.
+- `npm run preview --prefix web` – Serve the production build locally.
+- `npm run lint --prefix web` – Run ESLint with the project ruleset.
+- `npm run test --prefix web` – Execute the Vitest suite (placeholder until gameplay logic matures).
+
+## Project Structure
+- `src/` – TypeScript source files. Phaser scenes live under `src/scenes/`.
+- `content/` – JSON data for quests, world regions, and encounter tuning.
+- `public/` – Static assets copied directly into the final bundle (sprites, audio, shaders).
+- `tests/` – Unit test entry point (to be filled out as systems migrate).
+
+## Next Steps
+- Flesh out additional Phaser scenes for hero stealth runs and dark lord command phases.
+- Port resource and stealth systems from the design doc into TypeScript modules with matching tests.
+- Integrate lightweight backend telemetry once the Codespaces preview endpoint is available.

--- a/web/content/quests.json
+++ b/web/content/quests.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "scout_roads",
+    "title": "Scout the Hidden Roads",
+    "description": "Send shades to reveal safe passages for the hero caravan. Avoid patrols to keep dread low.",
+    "reward": 3
+  },
+  {
+    "id": "steal_relic",
+    "title": "Steal Relic of Dawnspear",
+    "description": "Infiltrate the chapel during the eclipse to recover the relic before the paladins regroup.",
+    "reward": 5
+  },
+  {
+    "id": "bind_warlord",
+    "title": "Bind the Broken Warlord",
+    "description": "Subdue the marauding warlord with spectral chains so he may guard the dominion borders.",
+    "reward": 4
+  }
+]

--- a/web/content/world.json
+++ b/web/content/world.json
@@ -1,0 +1,20 @@
+{
+  "name": "Dominion Frontier",
+  "regions": [
+    {
+      "id": "shadow_forest",
+      "label": "Shadowed Forest",
+      "threat": 2
+    },
+    {
+      "id": "ashen_keep",
+      "label": "Ashen Keep",
+      "threat": 4
+    },
+    {
+      "id": "fey_crossing",
+      "label": "Fey Crossing",
+      "threat": 3
+    }
+  ]
+}

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Grimm Dominion Prototype</title>
+  </head>
+  <body>
+    <div id="game"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "grimmdominion-web",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint \"src/**/*.{ts,tsx}\"",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "phaser": "^3.70.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.24",
+    "@typescript-eslint/eslint-plugin": "^6.21.0",
+    "@typescript-eslint/parser": "^6.21.0",
+    "eslint": "^8.56.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-import": "^2.29.1",
+    "prettier": "^3.2.5",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.12",
+    "vitest": "^1.3.1"
+  }
+}

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -1,0 +1,20 @@
+import Phaser from "phaser";
+
+import { BootScene } from "./scenes/BootScene";
+import { MapScene } from "./scenes/MapScene";
+
+const config: Phaser.Types.Core.GameConfig = {
+  type: Phaser.AUTO,
+  parent: "game",
+  backgroundColor: "#120b22",
+  scale: {
+    mode: Phaser.Scale.FIT,
+    autoCenter: Phaser.Scale.CENTER_BOTH,
+    width: 1280,
+    height: 720
+  },
+  scene: [BootScene, MapScene]
+};
+
+// eslint-disable-next-line no-new
+new Phaser.Game(config);

--- a/web/src/scenes/BootScene.ts
+++ b/web/src/scenes/BootScene.ts
@@ -1,0 +1,21 @@
+import Phaser from "phaser";
+
+import { MapSceneKey } from "./MapScene";
+
+export const BootSceneKey = "boot";
+
+export class BootScene extends Phaser.Scene {
+  constructor() {
+    super(BootSceneKey);
+  }
+
+  preload(): void {
+    this.load.setPath("/content");
+    this.load.json("world-config", "world.json");
+    this.load.json("quest-deck", "quests.json");
+  }
+
+  create(): void {
+    this.scene.start(MapSceneKey);
+  }
+}

--- a/web/src/scenes/MapScene.ts
+++ b/web/src/scenes/MapScene.ts
@@ -1,0 +1,60 @@
+import Phaser from "phaser";
+
+interface QuestDefinition {
+  id: string;
+  title: string;
+  description: string;
+  reward: number;
+}
+
+interface WorldConfig {
+  name: string;
+  regions: Array<{
+    id: string;
+    label: string;
+    threat: number;
+  }>;
+}
+
+export const MapSceneKey = "map";
+
+export class MapScene extends Phaser.Scene {
+  private quests: QuestDefinition[] = [];
+  private worldConfig: WorldConfig | null = null;
+
+  constructor() {
+    super(MapSceneKey);
+  }
+
+  create(): void {
+    this.worldConfig = this.cache.json.get("world-config") as WorldConfig;
+    this.quests = this.cache.json.get("quest-deck") as QuestDefinition[];
+
+    this.add.text(32, 32, "Grimm Dominion Prototype", {
+      fontFamily: "serif",
+      fontSize: "36px",
+      color: "#f8e9d3"
+    });
+
+    const regionText = this.worldConfig.regions
+      .map((region) => `${region.label} — threat ${region.threat}`)
+      .join("\n");
+    this.add.text(32, 96, `Regions:\n${regionText}`, {
+      fontFamily: "monospace",
+      fontSize: "20px",
+      color: "#b1a7f6",
+      lineSpacing: 12
+    });
+
+    const questLines = this.quests
+      .map((quest) => `• ${quest.title} (+${quest.reward} dread)\n  ${quest.description}`)
+      .join("\n\n");
+    this.add.text(640, 96, `Quest Deck\n${questLines}`, {
+      fontFamily: "monospace",
+      fontSize: "18px",
+      color: "#f6d6ff",
+      wordWrap: { width: 520 },
+      lineSpacing: 10
+    });
+  }
+}

--- a/web/tests/example.test.ts
+++ b/web/tests/example.test.ts
@@ -1,0 +1,7 @@
+import { describe, expect, it } from "vitest";
+
+describe("placeholder", () => {
+  it("confirms the prototype harness is wired", () => {
+    expect(true).toBe(true);
+  });
+});

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["vitest", "vite/client"]
+  },
+  "include": ["src", "vite.config.ts", "vite-env.d.ts", "tests"]
+}

--- a/web/vite-env.d.ts
+++ b/web/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  server: {
+    host: "0.0.0.0",
+    port: 5173
+  },
+  preview: {
+    host: "0.0.0.0",
+    port: 5173
+  }
+});


### PR DESCRIPTION
## Summary
- pivot the technology reference to a Phaser- and Vite-based browser prototype pipeline
- add a `web/` workspace with Vite configuration, Phaser bootstrap scenes, and sample content data
- document Codespaces commands and scripts for running and building the browser slice

## Testing
- not run (documentation and scaffolding only)

------
https://chatgpt.com/codex/tasks/task_e_68e3c6ebe0488332bfec694cde42675e