### PR TITLE
Update devcontainer to supported Unity image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Grimm Dominion Unity Codespace",
-  "image": "ghcr.io/game-ci/unity3d:ubuntu-2022.3.21f1-base-3.0",
+  "image": "unityci/editor:ubuntu-2022.3.21f1-base-3.0",
   "features": {
     "ghcr.io/devcontainers/features/git-lfs:1": {},
     "ghcr.io/devcontainers/features/github-cli:1": {}

--- a/docs/prototype/technology.md
+++ b/docs/prototype/technology.md
@@ -28,6 +28,10 @@
   asset pipeline for hashed production filenames.
 
 ## Codespaces Environment
+
+- Codespace container pulls from `unityci/editor:ubuntu-2022.3.21f1-base-3.0` so Unity dependencies
+  stay accessible without relying on deprecated GameCI image aliases. Update the tag alongside
+  Unity version bumps.
 - Launch the repository in GitHub Codespaces and run `npm install --prefix web` to pull down Phaser,
   TypeScript, Vite, and linting dependencies.
 - Start development with `npm run dev --prefix web -- --host 0.0.0.0 --port 5173` so the Vite server


### PR DESCRIPTION
## Summary
- switch the Codespaces container to the maintained `unityci/editor` base image
- document the new image source in the technology guide to avoid future pull failures

## Testing
- not run (documentation and configuration updates only)


------
https://chatgpt.com/codex/tasks/task_e_68e3cdf258c0833282eb246ab1d0614d