### PR TITLE
Adjust Phaser imports to resolve lint warnings

### DIFF
--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -1,15 +1,15 @@
-import Phaser from "phaser";
+import { AUTO, Game, Scale, type Types } from "phaser";
 
 import { BootScene } from "./scenes/BootScene";
 import { MapScene } from "./scenes/MapScene";
 
-const config: Phaser.Types.Core.GameConfig = {
-  type: Phaser.AUTO,
+const config: Types.Core.GameConfig = {
+  type: AUTO,
   parent: "game",
   backgroundColor: "#120b22",
   scale: {
-    mode: Phaser.Scale.FIT,
-    autoCenter: Phaser.Scale.CENTER_BOTH,
+    mode: Scale.FIT,
+    autoCenter: Scale.CENTER_BOTH,
     width: 1280,
     height: 720
   },
@@ -17,4 +17,4 @@ const config: Phaser.Types.Core.GameConfig = {
 };
 
 // eslint-disable-next-line no-new
-new Phaser.Game(config);
+new Game(config);

--- a/web/src/scenes/BootScene.ts
+++ b/web/src/scenes/BootScene.ts
@@ -1,10 +1,10 @@
-import Phaser from "phaser";
+import { Scene } from "phaser";
 
 import { MapSceneKey } from "./MapScene";
 
 export const BootSceneKey = "boot";
 
-export class BootScene extends Phaser.Scene {
+export class BootScene extends Scene {
   constructor() {
     super(BootSceneKey);
   }


### PR DESCRIPTION
## Summary
- switch the game bootstrap to Phaser named imports for AUTO, Scale, and Game
- update BootScene and MapScene to extend Phaser's Scene class via named imports
- replace namespace-style references in MapScene with named imports for Math, Display, Geom, and type helpers to silence lint warnings

## Testing
- npm run lint *(fails: ESLint 9 now expects eslint.config.js instead of legacy .eslintrc)*

------
https://chatgpt.com/codex/tasks/task_e_68e3d74af5c48332931dafe6298da754