### PR TITLE
Add root npm manifest to streamline web installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Grimm Dominion Repository Guide
+
+This repository contains both the Unity prototype assets and the browser-based vertical slice that
+runs in GitHub Codespaces. Follow the steps below to get the web build running.
+
+## Quick Start in Codespaces
+1. Install dependencies from the repository root:
+   ```bash
+   npm install
+   ```
+   The root manifest proxies installation to the `web/` workspace so the required packages are
+   downloaded automatically.
+2. Start the development server (bind to all interfaces for Codespaces):
+   ```bash
+   npm run dev
+   ```
+3. Open the forwarded port (default `5173`) to interact with the prototype.
+
+For more details about the browser build, including available npm scripts and folder structure, see
+[`web/README.md`](web/README.md).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "grimm-dominion",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "grimm-dominion",
+      "hasInstallScript": true,
+      "license": "UNLICENSED"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "grimm-dominion",
+  "private": true,
+  "description": "Monorepo manifest for the Grimm Dominion project.",
+  "license": "UNLICENSED",
+  "scripts": {
+    "postinstall": "npm install --prefix web",
+    "install:web": "npm install --prefix web",
+    "dev": "npm run dev --prefix web -- --host 0.0.0.0 --port 5173",
+    "build": "npm run build --prefix web",
+    "preview": "npm run preview --prefix web",
+    "lint": "npm run lint --prefix web",
+    "test": "npm run test --prefix web"
+  }
+}


### PR DESCRIPTION
## Summary
- add a root `package.json` that forwards installation and npm scripts to the `web/` workspace so `npm install` succeeds from the repository root
- document quick start instructions for running the browser prototype in Codespaces

## Testing
- npm install

------
https://chatgpt.com/codex/tasks/task_e_68e3df0d88988332a38670c2551a3f3a