### PR TITLE
Retarget docs to browser-based prototype

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Repository Structure
 - `Design_Document/Design_Document`: Primary game design reference (PDF). Keep it unchanged unless a new authoritative design is provided.
-- `docs/prototype/`: Planning hub for the vertical slice prototype. Each Markdown file drills into a specific discipline:
+- `docs/prototype/`: Planning hub for the browser-based vertical slice. Each Markdown file drills into a specific discipline:
   - `README.md`: Entry point linking the specialist documents below.
   - `vision.md`: Goals, success metrics, and scope guardrails.
   - `roles.md`: Dark Lord and hero role loops, including economy notes.
@@ -19,16 +19,18 @@ Add new documentation under `docs/` with topical subfolders and cross-link them 
 - Prefer Markdown (`.md`) for design and planning artifacts. Use level-1 headings for file titles and level-2 headings for top-level sections.
 - Wrap lines at ~100 characters for readability. Use bullet or numbered lists for structured content.
 - When adding code in future sprints:
-  - Follow Unity C# conventions: PascalCase for types/methods, camelCase for locals/parameters, `I`-prefixed interface names.
-  - Keep public APIs documented with XML comments. Group related scripts under `Assets/Scripts/<Feature>`.
+  - Follow TypeScript/Phaser conventions: PascalCase for classes, camelCase for locals/parameters, and
+    co-locate modules under `web/src/<Feature>`.
+  - Document public APIs with TSDoc comments. Group related gameplay systems under
+    `web/src/game/systems/<Feature>`.
   - Avoid `try/catch` around imports (per global instructions).
 - For JSON/YAML configs, use two-space indentation and double quotes for keys/strings.
 
 ## Testing Protocols
 - Documentation changes: No automated tests required; proofread for clarity and broken links.
-- Unity gameplay code (when present):
-  - Run play mode/unit tests via `Unity -runTests -testPlatform editmode` before committing.
-  - Use `dotnet test` for standalone C# projects or tooling.
+- Browser gameplay code:
+  - Run `npm run lint --prefix web` and `npm run test --prefix web` before committing.
+  - Use `npm run test:e2e --prefix web` when modifying Playwright flows.
 - If introducing build scripts or pipelines, document command usage in the relevant README and reference them in commit messages.
 
 ## Pull Request Guidelines

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Grimm Dominion Repository Guide
 
-This repository contains both the Unity prototype assets and the browser-based vertical slice that
-runs in GitHub Codespaces. Follow the steps below to get the web build running.
+This repository contains the browser-based vertical slice for Grimm Dominion. The prototype is
+implemented with a TypeScript/Phaser stack and is intended to run entirely in the browser, making it
+easy to iterate inside GitHub Codespaces or a local development environment. Follow the steps below
+to get the web build running.
 
 ## Quick Start in Codespaces
 1. Install dependencies from the repository root:

--- a/docs/prototype/file_creation_checklist.md
+++ b/docs/prototype/file_creation_checklist.md
@@ -1,101 +1,78 @@
 # Prototype File Creation Checklist
 
 ## Purpose
-This checklist translates the vertical slice blueprint into concrete Unity project files so the
+This checklist translates the vertical slice blueprint into concrete browser project files so the
 prototype can boot, connect players, and deliver the outlined match flow. Treat each item as a
 tracked task in your project board and link completed assets back to their owning discipline.
 
 ## Project Bootstrapping
-1. **Create Unity Project** using *Unity 2022 LTS (URP template)*.
-2. **Configure Source Control**
-   - Enable *Visible Meta Files* and *Force Text* serialization.
-   - Add Git LFS for future binary art/audio drops.
-3. **Install Required Packages** via Package Manager
-   - Universal Render Pipeline, Input System, Cinemachine.
-   - Photon Fusion SDK and Addressables.
-   - Behavior tree tooling (Behavior Designer or custom) for AI scripting.
-4. **Set Up Folder Structure** under `Assets/`
-   - `Scenes/`, `Scripts/`, `Art/`, `Audio/`, `UI/`, `Prefabs/`, `ScriptableObjects/`, `NetCode/`,
-     `Tests/`.
-   - Mirror structure in `Assets/AddressableAssets/` for streamed content.
+1. **Scaffold Workspace** using `npm create vite@latest web -- --template vanilla-ts`.
+2. **Install Dependencies**
+   - Runtime: `phaser`, `@pixi/layers`, `howler`, `zustand`, `immer`, `date-fns`.
+   - Tooling: `vitest`, `@vitest/coverage-c8`, `@testing-library/dom`, `eslint`,
+     `@typescript-eslint/*`, `prettier`, `playwright` (optional follow-up).
+3. **Configure Tooling**
+   - Add shared ESLint/Prettier configs.
+   - Configure `tsconfig.json` paths for `@game/*`, `@content/*`, and `@core/*` aliases.
+   - Create `.vscode/settings.json` enabling format on save and pointing to the workspace TypeScript
+     version.
 
-## Scenes & Game Flow Assets
-- `Assets/Scenes/Boot.unity`: loads services, handles build hash checks, transitions to Lobby.
-- `Assets/Scenes/Lobby.unity`: role selection UI, Photon room creation, match start countdown.
-- `Assets/Scenes/CastlePlateau_VSlice.unity`: main match scene stitching castle plateau + three
-  biome chunks with navmesh baking hooks.
-- **Scene Script Files**
-  - `Scripts/Boot/BootFlowController.cs`: orchestrates service initialization.
-  - `Scripts/Lobby/LobbyUIController.cs`: binds Input System to role selection widgets.
-  - `Scripts/Match/MatchBootstrap.cs`: requests chunk layout seed and instantiates gameplay
-    managers.
-- **Addressable Profiles**
-  - Define *Editor*, *Android*, *iOS* profiles with build/load paths for streamed bundles.
+## Scenes & Game Flow Modules
+- `src/game/scenes/BootScene.ts`: Preloads atlases/audio/JSON, seeds global stores, transitions to
+  lobby.
+- `src/game/scenes/LobbyScene.ts`: Handles role selection UI, match settings, and tutorial overlays.
+- `src/game/scenes/MatchScene.ts`: Instantiates biome tilemaps, unit factories, quest managers, and
+  HUD layers.
+- `src/game/scenes/SceneRegistry.ts`: Helper for registering/unregistering scenes in tests.
+- **Routing**: Add `src/main.ts` entry that mounts Phaser with BootScene as the starting point.
 
-## Scriptable Object Data
-Create the following ScriptableObject definitions and populate at least one instance for the slice.
+## State & Data Modules
+Create strongly typed stores and schema definitions:
 
 | File | Location | Purpose |
 | --- | --- | --- |
-| `AbilityDefinition.cs` | `Scripts/Data/` | Configures ability costs, cooldowns, FX references. |
-| `UnitDefinition.cs` | `Scripts/Data/` | Stats for heroes/minions, including nav agent radius. |
-| `QuestDefinition.cs` | `Scripts/Data/` | Quest steps, triggers, reward hooks. |
-| `ResourceCurve.cs` | `Scripts/Data/` | Economy income/expense curves per role. |
-| `ChunkLayoutDefinition.cs` | `Scripts/Data/` | Lists biome chunk prefabs, spawn markers. |
+| `gameStore.ts` | `src/state/` | Central Zustand store for role, phase, and victory state. |
+| `resourceSlice.ts` | `src/state/slices/` | Manages Evil Energy, Valor, Gold tick cadence. |
+| `questSlice.ts` | `src/state/slices/` | Tracks quest progression and triggers UI updates. |
+| `contentSchemas.ts` | `src/content/schemas/` | `zod` schemas validating quest/encounter JSON. |
+| `questCatalog.json` | `src/content/quests/` | Defines stealth, escort, and ritual quest flows. |
+| `encounterTable.json` | `src/content/encounters/` | Enemy spawn compositions by escalation level. |
+| `roleLoadouts.json` | `src/content/roles/` | Ability loadouts and tutorial tips per role. |
 
-Store instances under `ScriptableObjects/Abilities`, `.../Units`, etc. Reference them from role
-controllers and quest managers to avoid hard-coded data.
+## Systems & Gameplay Logic
+Implement the following TypeScript modules under `src/game/systems/`:
 
-## Prefabs & Environment Assembly
-- **Heroes**: `Prefabs/Heroes/ExiledKnight.prefab`, `.../GoblinOutlaw.prefab` containing character
-  controller, ability harness, animation placeholders, and Photon network object.
-- **Dark Lord Commander**: `Prefabs/DarkLord/CommanderRig.prefab` with camera rig, UI anchors,
-  command selection widgets.
-- **Minions**: skeletons, imps, bonecrusher prefabs with behavior tree component, nav agent, health.
-- **Interactive Props**: gate, shrine, villager cages, gold caches, tavern, ritual node prefabs with
-  collider, interaction script, and Addressable labels.
-- **Biome Chunks**: blockout prefab variants per biome, including spawn markers (`Empty` child
-  transforms) for objectives and AI.
+- `economy/ResourceManager.ts`: Applies income curves, publishes events for HUD updates.
+- `fog/FogController.ts`: Maintains visibility textures using WebGL shaders with Canvas fallback.
+- `stealth/NoiseField.ts`: Tracks noise pulses, decays them over time, informs commander alerts.
+- `quests/QuestManager.ts`: Loads quest definitions, handles objective completion and rewards.
+- `units/AbilityExecutor.ts`: Validates targets, plays animations, and schedules cooldowns.
+- `units/SpawnFactory.ts`: Instantiates Phaser game objects for minions with physics bodies.
+- `telemetry/TelemetryClient.ts`: Buffers match summaries and posts to configured webhook.
 
-## Systems & Gameplay Scripts
-Create the following C# files under `Assets/Scripts/`:
-
-- `Systems/FogOfWar/FogService.cs`, `Systems/FogOfWar/FogRenderer.cs`: manage visibility masks and
-  render textures.
-- `Systems/Stealth/NoiseEventSystem.cs`: broadcast noise events to commander HUD and hero widgets.
-- `Systems/Economy/ResourceManager.cs`: replicate Evil Energy, Valor, Gold; expose events for UI.
-- `Systems/Quests/QuestManager.cs`: load quest definitions, track progress, trigger objectives.
-- `Systems/Units/AbilityExecutor.cs`: handles cooldowns, validation, VFX hooks for abilities.
-- `Systems/Networking/PhotonBootstrap.cs`: wraps Photon Fusion connection, reconnection, room
-  handling.
-- `Systems/Telemetry/TelemetryClient.cs`: buffers match metrics and posts at match end.
-
-Each system should include play mode tests in `Assets/Tests/EditMode/` verifying core behaviors (e.g.
-resource replication, quest completion triggers).
+Unit-test deterministic logic with Vitest specs under `tests/unit/`.
 
 ## UI & UX Assets
-- `UI/Prefabs/HUD/HeroHUD.prefab` and `UI/Prefabs/HUD/DarkLordHUD.prefab` with ability buttons,
-  resource meters, minimap, and tutorial prompt anchors.
-- `UI/Prefabs/Menus/PauseMenu.prefab`, `UI/Prefabs/Menus/MatchSummary.prefab`.
-- Input System action maps: `CommanderControls.inputactions`, `HeroControls.inputactions` with mobile
-  control schemes.
-- `UI/Scripts/HUD/HUDController.cs`: binds resource events and quest updates.
-- `UI/Scripts/Tutorial/TutorialPromptManager.cs`: sequences onboarding callouts.
+- `src/game/ui/hud/HeroHud.ts`: Displays hero health, abilities, stealth meter, quest tracker.
+- `src/game/ui/hud/DarkLordHud.ts`: Shows minion roster, Evil Energy, map overview, alert feed.
+- `src/game/ui/overlays/TutorialOverlay.ts`: Guides first-match actions with dismissible steps.
+- `src/styles/tokens.scss`: Centralized spacing/color/typography tokens for Phaser and DOM overlays.
+- Input mapping JSON in `src/config/inputBindings.json` describing keyboard/mouse bindings.
 
 ## Audio Implementation Files
-- Create FMOD (or Unity audio) banks for *ambient*, *combat*, *UI* layers.
-- Author AudioSource prefabs for noise cues, ability triggers, gate damage.
-- `Audio/Scripts/AdaptiveMusicController.cs`: swaps music states based on quest phase.
-- Ensure Addressable labels for streamed audio clips.
+- Place ambient/combat/UI tracks in `public/audio/`.
+- `src/game/audio/AdaptiveMusicController.ts`: Switches playlists based on quest phase and tension.
+- `src/game/audio/SfxBus.ts`: Queues positional SFX and throttles repeats.
+- Reference audio assets via Howler wrappers to keep loading async-friendly.
 
 ## Build & Automation
-- `ProjectSettings/Graphics` configured for URP asset; `QualitySettings` tuned for mobile defaults.
-- `Editor/Build/BuildPipeline.cs`: defines CI entry point producing Android/iOS dev builds.
-- GitHub Actions workflow stub referencing Unity builder action, running play mode tests and
-  packaging Addressables.
+- `.github/workflows/web-ci.yml`: Runs `npm ci`, `npm run lint`, `npm run test`, `npm run build`.
+- `vitest.config.ts`: Enables `jsdom` environment and coverage thresholds.
+- `playwright.config.ts`: Seeds hero/dark-lord smoke flows (optional follow-up).
+- `scripts/upload-telemetry.ts`: CLI helper for replaying telemetry payloads to staging (future).
 
 ## Verification Checklist
-- Play mode test suite green on editor hardware.
-- Three-player network session connects via Photon Fusion using local room ID.
-- Match completes full quest arc with telemetry payload posted to configured endpoint.
-- Android/iOS development builds deploy to reference devices without missing asset exceptions.
+- Vite dev server boots (`npm run dev`) and exposes port `5173` for Codespaces.
+- `npm run lint` and `npm run test` succeed locally and in CI.
+- Playwright smoke (`npm run test:e2e`) covers lobby -> match -> summary flow (once implemented).
+- Build artifact (`npm run build`) deploys via static hosting without missing asset references.

--- a/docs/prototype/systems.md
+++ b/docs/prototype/systems.md
@@ -15,7 +15,9 @@
   - *Scout Imp:* Fast, low damage, high vision. Patrol paths and report sightings.
   - *Bonecrusher:* Tanky melee unit with gate-guard behavior. Reacts to pings by converging.
   - *Hex Priest:* Ranged support that channels debuffs, vulnerable when interrupted.
-- **Behavior Trees:** Authored in Unity using scriptable nodes. Server sends intention packets; clients simulate for responsiveness with reconciliation.
+- **Behavior Trees:** Authored as JSON-driven behavior graphs interpreted by the Phaser AI runtime.
+  Server hooks remain optional; the client simulates intentions locally with reconciliation stubs for
+  future networking.
 - **Escalation Rules:** Unlock stronger minion waves at 5 and 10-minute marks, triggered by castle energy thresholds.
 
 ## Combat & Progression


### PR DESCRIPTION
## Summary
- align the repo overview and contributor guide with the browser-first Phaser/TypeScript stack
- replace the Unity-centric project bootstrap plan with Vite workspace scaffolding instructions
- update the prototype file checklist and systems brief to reference web modules and data assets

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e3e5c3bde483329f1e99ed50b90ac9