### PR TITLE
Add world placement helpers and demo props

### DIFF
--- a/src/scenes/World.ts
+++ b/src/scenes/World.ts
@@ -34,6 +34,17 @@ export class World extends Phaser.Scene {
     });
 
     this.scene.launch('hud', { world: this });
+
+    // demo flora/structures
+    for (let i = 0; i < 12; i++) {
+      const fx = 64 + Math.random() * 384;
+      const fy = 64 + Math.random() * 384;
+      this.add.image(fx, fy, 'tiles').setFrame(2).setAlpha(0.9); // bush
+    }
+    // placeholder structure (village hut)
+    this.add.image(320, 160, 'tiles').setFrame(3).setScale(1.2);
+    // light fx
+    this.add.rectangle(320, 160, 40, 40, 0xffff00, 0.1).setBlendMode(Phaser.BlendModes.ADD);
   }
 
   update(_time: number, dt: number): void {

--- a/src/world/placement.ts
+++ b/src/world/placement.ts
@@ -1,0 +1,16 @@
+import type { Vec2 } from '../types';
+
+export const toIso = (x: number, y: number, til = 32): Vec2 => ({
+  x: ((x - y) * til) / 2,
+  y: ((x + y) * til) / 4
+});
+
+export function placeGrid(cols: number, rows: number, til = 32): Vec2[] {
+  const out: Vec2[] = [];
+  for (let y = 0; y < rows; y++) {
+    for (let x = 0; x < cols; x++) {
+      out.push({ x: x * til, y: y * til });
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary
- add reusable world placement helpers for isometric conversions and grid generation
- populate the world scene with temporary bushes, hut, and light effect for spatial demo

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3e76a820c8332825d7b4ad49f2cfb