### PR TITLE
Restore world rendering by embedding tileset assets

### DIFF
--- a/public/tilemap.json
+++ b/public/tilemap.json
@@ -42,7 +42,16 @@
   "tilesets": [
     {
       "firstgid": 1,
-      "source": "tiles.tsx"
+      "name": "tiles",
+      "tilewidth": 32,
+      "tileheight": 32,
+      "spacing": 0,
+      "margin": 0,
+      "tilecount": 8,
+      "columns": 8,
+      "image": "tiles.png",
+      "imagewidth": 256,
+      "imageheight": 32
     }
   ],
   "tilewidth": 32,

--- a/public/tiles.png
+++ b/public/tiles.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:27adea72cf4a43661229267e49993256dfe3649c8482d65c754567f4e8f63f8e
-size 229
+oid sha256:84ac1aaacba42d2884f755a419ed4934bf165bea160528b603fd652efe5cb512
+size 292

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@ import { Boot } from './scenes/Boot';
 import { World } from './scenes/World';
 import { HUD } from './ui/HUD';
 
-new Phaser.Game({
+const game = new Phaser.Game({
   type: Phaser.AUTO,
   parent: 'app',
   width: 960,
@@ -12,3 +12,5 @@ new Phaser.Game({
   physics: { default: 'arcade', arcade: { debug: false } },
   scene: [Boot, World, HUD]
 });
+
+(window as any).game = game;

--- a/src/scenes/Boot.ts
+++ b/src/scenes/Boot.ts
@@ -6,7 +6,10 @@ export class Boot extends Phaser.Scene {
   }
 
   preload(): void {
-    this.load.image('tiles', '/tiles.png');
+    this.load.spritesheet('tiles', '/tiles.png', {
+      frameWidth: 32,
+      frameHeight: 32
+    });
     this.load.tilemapTiledJSON('map', '/tilemap.json');
   }
 

--- a/src/scenes/World.ts
+++ b/src/scenes/World.ts
@@ -14,9 +14,13 @@ export class World extends Phaser.Scene {
   create(): void {
     this.map = this.make.tilemap({ key: 'map' });
     const tiles = this.map.addTilesetImage('tiles', 'tiles', 32, 32, 0, 0);
-    this.layer = this.map.createLayer('ground', tiles!, 0, 0)!;
+    if (!tiles) {
+      console.error('Tileset "tiles" failed to load.');
+      return;
+    }
+    this.layer = this.map.createLayer('ground', tiles, 0, 0)!;
 
-    this.hero = this.add.sprite(160, 160, 'tiles').setFrame(1) as any;
+    this.hero = this.add.sprite(160, 160, 'tiles', 1) as any;
     this.physics.add.existing(this.hero);
     this.hero.speed = 100;
     this.hero.stats = {

--- a/src/ui/HUD.ts
+++ b/src/ui/HUD.ts
@@ -34,7 +34,6 @@ export class HUD extends Phaser.Scene {
     add.text(width - 160, height - 58, 'Stealth', { fontSize: '12px' });
     this.stealthBar = add.rectangle(width - 90, height - 58, 120, 10, 0x2ecc71).setOrigin(0, 0.5);
 
-    this.cameras.main.setBackgroundColor(0x000000);
     this.cameras.main.setScroll(0, 0);
   }
 


### PR DESCRIPTION
## Summary
- embed the Tiled tileset data in the tilemap and supply a simple tilesheet so textures load correctly
- load the tilesheet as a spritesheet and guard against missing tileset data when constructing the world scene
- prevent the HUD camera from clearing the canvas and expose the Phaser game instance for easier debugging

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3e8d78ea483329edfd32bd51ca36c