### PR TITLE
Add spawners for village villagers and fauna

### DIFF
--- a/src/scenes/World.ts
+++ b/src/scenes/World.ts
@@ -29,7 +29,7 @@ export class World extends Phaser.Scene {
     super('world');
   }
 
-  create(): void {
+  async create(): Promise<void> {
     this.iso = {
       tileWidth: 64,
       tileHeight: 32,
@@ -82,6 +82,10 @@ export class World extends Phaser.Scene {
     this.scene.launch('hud', { world: this });
 
     this.populateProps();
+
+    const { spawnVillage, spawnFauna } = await import('../world/spawners');
+    spawnVillage(this, 320, 160);
+    spawnFauna(this, 6);
   }
 
   update(_time: number, dt: number): void {

--- a/src/world/spawners.ts
+++ b/src/world/spawners.ts
@@ -1,0 +1,34 @@
+import type { World } from '../scenes/World';
+
+export function spawnVillage(w: World, x: number, y: number) {
+  w.add.image(x, y, 'tiles').setFrame(3).setScale(1.2);
+  for (let i = 0; i < 3; i++) {
+    const vx = x + Math.random() * 40 - 20;
+    const vy = y + Math.random() * 40 - 20;
+    const vill = w.add.sprite(vx, vy, 'tiles').setFrame(4);
+    w.tweens.add({
+      targets: vill,
+      x: vx + 20 * Math.sin(Math.random() * 6),
+      y: vy + 20 * Math.cos(Math.random() * 6),
+      duration: 4000,
+      yoyo: true,
+      repeat: -1,
+    });
+  }
+}
+
+export function spawnFauna(w: World, n = 6) {
+  for (let i = 0; i < n; i++) {
+    const fx = 100 + Math.random() * 400;
+    const fy = 100 + Math.random() * 400;
+    const crit = w.add.sprite(fx, fy, 'tiles').setFrame(5).setAlpha(0.8);
+    w.tweens.add({
+      targets: crit,
+      x: fx + 30 * Math.sin(Math.random() * 6),
+      y: fy + 30 * Math.cos(Math.random() * 6),
+      duration: 6000,
+      yoyo: true,
+      repeat: -1,
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add a world spawner module for villages and ambient fauna
- invoke the new spawners during world scene creation to populate the environment

## Testing
- npm run lint --prefix web
- npm run test --prefix web

------
https://chatgpt.com/codex/tasks/task_e_68e3f1fab9b88332885e80a0b1746a05