### PR TITLE
Add Dark Lord castle AI spawn and search loop

### DIFF
--- a/src/ai/darkLord.ts
+++ b/src/ai/darkLord.ts
@@ -1,0 +1,48 @@
+import type { Vec2 } from '../types';
+
+export type DLUnit = {
+  sprite: Phaser.GameObjects.Sprite;
+  kind: 'Scout' | 'Tank' | 'Priest';
+  speed: number;
+  vision: number;
+  state: 'Patrol' | 'Investigate' | 'Chase';
+  lastHeard?: Vec2;
+};
+
+export class DarkLordAI {
+  energy = 0;
+  cap = 5;
+  units: DLUnit[] = [];
+  lastPing: Vec2 | null = null;
+
+  constructor(private scene: Phaser.Scene, private castlePos: Vec2) {}
+
+  step(dt: number) {
+    this.energy += 0.5 * dt;
+  }
+
+  spawn(kind: 'Scout' | 'Tank' | 'Priest') {
+    if (this.units.length >= this.cap) {
+      return false;
+    }
+    const cost = { Scout: 10, Tank: 25, Priest: 20 }[kind];
+    if (this.energy < cost) {
+      return false;
+    }
+    this.energy -= cost;
+    const sprite = this.scene.add.sprite(this.castlePos.x + 16, this.castlePos.y, 'tiles').setFrame(6);
+    const speed = { Scout: 70, Tank: 40, Priest: 55 }[kind];
+    const vision = { Scout: 120, Tank: 80, Priest: 100 }[kind];
+    this.units.push({ sprite, kind, speed, vision, state: 'Patrol' });
+    return true;
+  }
+
+  directorTick() {
+    if (this.units.length < 2) {
+      this.spawn('Scout');
+    }
+    if (this.lastPing && this.energy >= 20) {
+      this.spawn('Priest');
+    }
+  }
+}

--- a/src/ai/search.ts
+++ b/src/ai/search.ts
@@ -1,0 +1,40 @@
+import type { DLUnit } from './darkLord';
+import type { Vec2 } from '../types';
+
+export function stepDLUnits(
+  units: DLUnit[],
+  hero: { x: number; y: number },
+  dt: number,
+  setAlert: (message: string) => void
+) {
+  for (const unit of units) {
+    const dx = hero.x - unit.sprite.x;
+    const dy = hero.y - unit.sprite.y;
+    const distance = Math.hypot(dx, dy);
+    if (distance < unit.vision) {
+      unit.state = 'Chase';
+      unit.lastHeard = { x: hero.x, y: hero.y };
+      setAlert('Spotted!');
+    }
+    if (unit.state === 'Patrol') {
+      const target: Vec2 = {
+        x: unit.sprite.x + Math.cos(performance.now() / 600) * 8,
+        y: unit.sprite.y + Math.sin(performance.now() / 600) * 8
+      };
+      moveToward(unit, target, dt);
+    } else if (unit.state === 'Chase' && unit.lastHeard) {
+      moveToward(unit, unit.lastHeard, dt, 1.3);
+    }
+  }
+}
+
+function moveToward(unit: DLUnit, target: Vec2, dt: number, multiplier = 1) {
+  const dx = target.x - unit.sprite.x;
+  const dy = target.y - unit.sprite.y;
+  const distance = Math.hypot(dx, dy) || 1;
+  const step = (unit.speed * multiplier * dt) / 1000;
+  if (distance > 1) {
+    unit.sprite.x += (dx / distance) * step;
+    unit.sprite.y += (dy / distance) * step;
+  }
+}


### PR DESCRIPTION
## Summary
- add a Dark Lord AI manager that handles energy, spawning, and director ticks
- implement a patrol/chase loop for Dark Lord units with alert messaging
- place a castle in the world scene and wire the AI step and unit updates into the scene lifecycle

## Testing
- npm run lint --prefix web
- npm run test --prefix web

------
https://chatgpt.com/codex/tasks/task_e_68e3f2096340833284a9119ef80b5f26