### PR TITLE
Add chest noise system and stealth hooks

### DIFF
--- a/src/systems/noise.ts
+++ b/src/systems/noise.ts
@@ -1,0 +1,20 @@
+import type { Vec2, NoiseEvent } from '../types';
+
+type Subscriber = (event: NoiseEvent) => void;
+
+const subscribers = new Set<Subscriber>();
+
+export const Noise = {
+  emit: (event: NoiseEvent) => subscribers.forEach((callback) => callback(event)),
+  on: (callback: Subscriber) => {
+    subscribers.add(callback);
+    return () => subscribers.delete(callback);
+  }
+};
+
+export const emitFootsteps = (pos: Vec2) =>
+  Noise.emit({
+    pos,
+    radius: 60,
+    kind: 'steps'
+  });

--- a/src/world/chest.ts
+++ b/src/world/chest.ts
@@ -1,0 +1,39 @@
+import Phaser from 'phaser';
+
+import { Noise } from '../systems/noise';
+
+export function addChest(scene: Phaser.Scene, x: number, y: number) {
+  const chest = scene.add.sprite(x, y, 'tiles').setFrame(8).setInteractive({ useHandCursor: true });
+  const bar = scene.add.rectangle(x, y - 20, 0, 6, 0xf1c40f).setOrigin(0.5, 0.5).setVisible(false);
+
+  let progress = 0;
+  let open = false;
+
+  chest.on('pointerdown', () => {
+    if (open) return;
+    bar.setVisible(true);
+    progress = 0;
+  });
+
+  scene.input.on('pointerup', () => {
+    progress = 0;
+    bar.setVisible(false);
+  });
+
+  scene.events.on('update', (_: unknown, dt: number) => {
+    if (!bar.visible || open) return;
+
+    progress += dt;
+    bar.width = Phaser.Math.Clamp((progress / 1500) * 32, 0, 32);
+
+    if (progress >= 1500) {
+      open = true;
+      bar.setVisible(false);
+      chest.setFrame(9);
+      Noise.emit({ pos: { x, y }, radius: 120, kind: 'chest' });
+      scene.events.emit('loot:gold', 15);
+    }
+  });
+
+  return chest;
+}


### PR DESCRIPTION
## Summary
- add a reusable noise event bus with helpers for footsteps
- create interactive chests that reward gold and emit loud noise when opened
- wire the world scene to spawn chests, handle loot, and alert dark lord units on noise events

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3f37de17883329e9f1c3571244846