### PR TITLE
Replace placeholder sprites with new art sheets

### DIFF
--- a/public/assets/Heros.png
+++ b/public/assets/Heros.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bff34301aab2eb1d91bc97a6da1d158721ef4b92ae476d6f369dc161c832ab22
+size 1800547

--- a/public/assets/Villages_flora_fauna.png
+++ b/public/assets/Villages_flora_fauna.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c731cb9188f08b7a74ecb6250c41b8840dffb7b14c84199371b51427018f6f55
+size 1613241

--- a/public/assets/characters.png
+++ b/public/assets/characters.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bff34301aab2eb1d91bc97a6da1d158721ef4b92ae476d6f369dc161c832ab22
+size 1800547

--- a/public/assets/effects_items.png
+++ b/public/assets/effects_items.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:91a69505979f5d276d08825456f8fa68bc3529b4240d9dce854930b8dedd672d
+size 1457791

--- a/src/ai/darkLord.ts
+++ b/src/ai/darkLord.ts
@@ -1,4 +1,5 @@
 import type { Vec2 } from '../types';
+import { EnemyFrames, SpriteKeys } from '../assets/sprites';
 
 export type DLUnit = {
   sprite: Phaser.GameObjects.Sprite;
@@ -30,7 +31,14 @@ export class DarkLordAI {
       return false;
     }
     this.energy -= cost;
-    const sprite = this.scene.add.sprite(this.castlePos.x + 16, this.castlePos.y, 'tiles').setFrame(6);
+    const sprite = this.scene.add
+      .sprite(
+        this.castlePos.x + 16,
+        this.castlePos.y,
+        SpriteKeys.enemies,
+        EnemyFrames[kind]
+      )
+      .setOrigin(0.5, 0.9);
     const speed = { Scout: 70, Tank: 40, Priest: 55 }[kind];
     const vision = { Scout: 120, Tank: 80, Priest: 100 }[kind];
     this.units.push({ sprite, kind, speed, vision, state: 'Patrol' });

--- a/src/assets/sprites.ts
+++ b/src/assets/sprites.ts
@@ -1,0 +1,32 @@
+export const SpriteKeys = {
+  heroes: 'heroes',
+  enemies: 'enemies',
+  settlements: 'settlements',
+  effects: 'effects'
+} as const;
+
+export const HeroFrames = {
+  goblinIdle: 30
+} as const;
+
+export const VillagerFrames = [32, 33, 34] as const;
+
+export const EnemyFrames = {
+  Scout: 0,
+  Tank: 8,
+  Priest: 16
+} as const;
+
+export const SettlementFrames = {
+  farmland: 0,
+  forest: 1,
+  hut: 2,
+  house: 18,
+  castle: 17,
+  shrub: 9,
+  stone: 48
+} as const;
+
+export const EffectFrames = {
+  chest: 9
+} as const;

--- a/src/scenes/Boot.ts
+++ b/src/scenes/Boot.ts
@@ -1,4 +1,5 @@
 import Phaser from 'phaser';
+import { SpriteKeys } from '../assets/sprites';
 
 export class Boot extends Phaser.Scene {
   constructor() {
@@ -6,44 +7,28 @@ export class Boot extends Phaser.Scene {
   }
 
   preload(): void {
-    this.createPlaceholderTextures();
+    this.load.setPath('assets');
+    this.load.spritesheet(SpriteKeys.heroes, 'Heros.png', {
+      frameWidth: 128,
+      frameHeight: 128
+    });
+    this.load.spritesheet(SpriteKeys.enemies, 'characters.png', {
+      frameWidth: 128,
+      frameHeight: 128
+    });
+    this.load.spritesheet(SpriteKeys.settlements, 'Villages_flora_fauna.png', {
+      frameWidth: 128,
+      frameHeight: 128
+    });
+    this.load.spritesheet(SpriteKeys.effects, 'effects_items.png', {
+      frameWidth: 128,
+      frameHeight: 128
+    });
+    this.load.setPath('');
   }
 
   create(): void {
     this.scene.start('world');
   }
 
-  private createPlaceholderTextures(): void {
-    if (this.textures.exists('hero-placeholder')) {
-      return;
-    }
-
-    const hero = this.make.graphics({ x: 0, y: 0, add: false });
-    const heroSize = 48;
-    hero.fillStyle(0x3b82f6, 1);
-    hero.fillCircle(heroSize / 2, heroSize / 2, 18);
-    hero.lineStyle(4, 0xffffff, 0.8);
-    hero.strokeCircle(heroSize / 2, heroSize / 2, 18);
-    hero.generateTexture('hero-placeholder', heroSize, heroSize);
-    hero.destroy();
-
-    const shrub = this.make.graphics({ x: 0, y: 0, add: false });
-    const shrubWidth = 64;
-    const shrubHeight = 48;
-    shrub.fillStyle(0x14532d, 1);
-    shrub.fillEllipse(shrubWidth / 2, shrubHeight * 0.75, shrubWidth / 2, shrubHeight / 2);
-    shrub.fillStyle(0x22c55e, 1);
-    shrub.fillEllipse(shrubWidth / 2, shrubHeight / 2, shrubWidth / 2.5, shrubHeight / 2.5);
-    shrub.generateTexture('prop-shrub-placeholder', shrubWidth, shrubHeight);
-    shrub.destroy();
-
-    const stone = this.make.graphics({ x: 0, y: 0, add: false });
-    const stoneSize = 32;
-    stone.fillStyle(0x6b7280, 1);
-    stone.fillRoundedRect(0, stoneSize / 2, stoneSize, stoneSize / 2, 6);
-    stone.lineStyle(2, 0x94a3b8, 0.8);
-    stone.strokeRoundedRect(2, stoneSize / 2 + 2, stoneSize - 4, stoneSize / 2 - 4, 6);
-    stone.generateTexture('prop-stone-placeholder', stoneSize, stoneSize);
-    stone.destroy();
-  }
 }

--- a/src/scenes/World.ts
+++ b/src/scenes/World.ts
@@ -5,6 +5,7 @@ import { addChest } from '../world/chest';
 import { Noise, emitFootsteps } from '../systems/noise';
 import { DarkLordAI } from '../ai/darkLord';
 import { stepDLUnits } from '../ai/search';
+import { HeroFrames, SettlementFrames, SpriteKeys } from '../assets/sprites';
 
 type HeroSprite = Phaser.GameObjects.Sprite & {
   stats: Stats;
@@ -54,7 +55,9 @@ export class World extends Phaser.Scene {
       y: this.iso.gridHeight / 2
     });
 
-    this.hero = this.add.sprite(heroStart.x, heroStart.y, 'hero-placeholder') as HeroSprite;
+    this.hero = this.add
+      .sprite(heroStart.x, heroStart.y, SpriteKeys.heroes, HeroFrames.goblinIdle)
+      as HeroSprite;
     this.hero.setOrigin(0.5, 0.9);
     this.physics.add.existing(this.hero);
     this.hero.speed = 3.5;
@@ -103,7 +106,10 @@ export class World extends Phaser.Scene {
 
     this.populateProps();
 
-    const castle = this.add.image(480, 240, 'tiles').setFrame(7).setScale(1.3);
+    const castle = this.add
+      .image(480, 240, SpriteKeys.settlements, SettlementFrames.castle)
+      .setOrigin(0.5, 0.9)
+      .setScale(1.1);
     this.darkLord = new DarkLordAI(this, { x: castle.x, y: castle.y });
     this.time.addEvent({ delay: 2000, loop: true, callback: () => this.darkLord.directorTick() });
     this.darkLord.spawn('Scout');
@@ -222,11 +228,21 @@ export class World extends Phaser.Scene {
   private populateProps(): void {
     const decorLayer = this.add.layer();
     const props = [
-      { key: 'prop-stone-placeholder', count: 6, depthOffset: 5 },
-      { key: 'prop-shrub-placeholder', count: 4, depthOffset: 12 }
+      {
+        key: SpriteKeys.settlements,
+        frame: SettlementFrames.stone,
+        count: 6,
+        depthOffset: 5
+      },
+      {
+        key: SpriteKeys.settlements,
+        frame: SettlementFrames.shrub,
+        count: 4,
+        depthOffset: 12
+      }
     ];
 
-    props.forEach(({ key, count, depthOffset }) => {
+    props.forEach(({ key, frame, count, depthOffset }) => {
       for (let i = 0; i < count; i++) {
         const cart = {
           x: Phaser.Math.FloatBetween(1, this.iso.gridWidth - 1),
@@ -234,7 +250,10 @@ export class World extends Phaser.Scene {
         };
         const screen = this.cartToScreen(cart);
         decorLayer.add(
-          this.add.image(screen.x, screen.y, key).setOrigin(0.5, 1).setDepth(screen.y + depthOffset)
+          this.add
+            .image(screen.x, screen.y, key, frame)
+            .setOrigin(0.5, 1)
+            .setDepth(screen.y + depthOffset)
         );
       }
     });

--- a/src/world/chest.ts
+++ b/src/world/chest.ts
@@ -1,9 +1,13 @@
 import Phaser from 'phaser';
 
+import { EffectFrames, SpriteKeys } from '../assets/sprites';
 import { Noise } from '../systems/noise';
 
 export function addChest(scene: Phaser.Scene, x: number, y: number) {
-  const chest = scene.add.sprite(x, y, 'tiles').setFrame(8).setInteractive({ useHandCursor: true });
+  const chest = scene.add
+    .sprite(x, y, SpriteKeys.effects, EffectFrames.chest)
+    .setOrigin(0.5, 0.9)
+    .setInteractive({ useHandCursor: true });
   const bar = scene.add.rectangle(x, y - 20, 0, 6, 0xf1c40f).setOrigin(0.5, 0.5).setVisible(false);
 
   let progress = 0;
@@ -29,7 +33,7 @@ export function addChest(scene: Phaser.Scene, x: number, y: number) {
     if (progress >= 1500) {
       open = true;
       bar.setVisible(false);
-      chest.setFrame(9);
+      chest.setFrame(EffectFrames.chest + 1);
       Noise.emit({ pos: { x, y }, radius: 120, kind: 'chest' });
       scene.events.emit('loot:gold', 15);
     }

--- a/src/world/spawners.ts
+++ b/src/world/spawners.ts
@@ -1,18 +1,27 @@
+import Phaser from 'phaser';
 import type { World } from '../scenes/World';
+import { SpriteKeys, SettlementFrames, VillagerFrames } from '../assets/sprites';
 
 export function spawnVillage(w: World, x: number, y: number) {
-  w.add.image(x, y, 'tiles').setFrame(3).setScale(1.2);
+  w.add
+    .image(x, y, SpriteKeys.settlements, SettlementFrames.house)
+    .setOrigin(0.5, 0.9)
+    .setScale(1.05);
   for (let i = 0; i < 3; i++) {
     const vx = x + Math.random() * 40 - 20;
     const vy = y + Math.random() * 40 - 20;
-    const vill = w.add.sprite(vx, vy, 'tiles').setFrame(4);
+    const villagerFrame = Phaser.Utils.Array.GetRandom(VillagerFrames);
+    const vill = w.add
+      .sprite(vx, vy, SpriteKeys.heroes, villagerFrame)
+      .setOrigin(0.5, 0.9)
+      .setDepth(vy + 2);
     w.tweens.add({
       targets: vill,
       x: vx + 20 * Math.sin(Math.random() * 6),
       y: vy + 20 * Math.cos(Math.random() * 6),
       duration: 4000,
       yoyo: true,
-      repeat: -1,
+      repeat: -1
     });
   }
 }
@@ -21,14 +30,18 @@ export function spawnFauna(w: World, n = 6) {
   for (let i = 0; i < n; i++) {
     const fx = 100 + Math.random() * 400;
     const fy = 100 + Math.random() * 400;
-    const crit = w.add.sprite(fx, fy, 'tiles').setFrame(5).setAlpha(0.8);
+    const crit = w.add
+      .sprite(fx, fy, SpriteKeys.settlements, SettlementFrames.forest)
+      .setOrigin(0.5, 0.9)
+      .setDepth(fy + 1)
+      .setAlpha(0.8);
     w.tweens.add({
       targets: crit,
       x: fx + 30 * Math.sin(Math.random() * 6),
       y: fy + 30 * Math.cos(Math.random() * 6),
       duration: 6000,
       yoyo: true,
-      repeat: -1,
+      repeat: -1
     });
   }
 }


### PR DESCRIPTION
## Summary
- add the supplied hero, enemy, village, and effects sprite sheets to the project
- expose reusable sprite keys and frame constants and load the sheets in the boot scene
- swap world interactions, AI spawns, and props to use the new art instead of generated placeholders

## Testing
- npm run lint --prefix web
- npm run test --prefix web

------
https://chatgpt.com/codex/tasks/task_e_68e3fa0116448332a901c373c337c844