### PR TITLE
Fix TypeScript cast causing build failure

### DIFF
--- a/src/scenes/World.ts
+++ b/src/scenes/World.ts
@@ -57,9 +57,12 @@ export class World extends Phaser.Scene {
       y: this.iso.gridHeight / 2
     });
 
-    this.hero = this.add
-      .sprite(heroStart.x, heroStart.y, SpriteKeys.heroes, HeroFrames.goblinIdle)
-      as HeroSprite;
+    this.hero = this.add.sprite(
+      heroStart.x,
+      heroStart.y,
+      SpriteKeys.heroes,
+      HeroFrames.goblinIdle
+    ) as HeroSprite;
     this.hero.setOrigin(0.5, 0.9);
     this.physics.add.existing(this.hero);
     this.hero.speed = this.heroBaseSpeed;


### PR DESCRIPTION
## Summary
- adjust the hero sprite initialization to use an inline TypeScript cast that esbuild can parse
- ensure the world scene compiles without triggering the previous parse error

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e40174ab588332870e4556faf7ed2d