### PR TITLE
Make HUD responsive to full-window layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,21 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>Grimm Dominion</title>
+    <style>
+      html,
+      body,
+      #app {
+        margin: 0;
+        padding: 0;
+        width: 100%;
+        height: 100%;
+        background: #0f0f13;
+        color: #e8e8ea;
+        overflow: hidden;
+      }
+    </style>
   </head>
-  <body style="margin:0;background:#0f0f13;color:#e8e8ea;">
+  <body>
     <div id="app"></div>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,11 +6,19 @@ import { HUD } from './ui/HUD';
 const game = new Phaser.Game({
   type: Phaser.AUTO,
   parent: 'app',
-  width: 960,
-  height: 540,
   backgroundColor: '#0f0f13',
   physics: { default: 'arcade', arcade: { debug: false } },
+  scale: {
+    mode: Phaser.Scale.RESIZE,
+    autoCenter: Phaser.Scale.CENTER_BOTH,
+    width: window.innerWidth,
+    height: window.innerHeight
+  },
   scene: [Boot, World, HUD]
+});
+
+window.addEventListener('resize', () => {
+  game.scale.resize(window.innerWidth, window.innerHeight);
 });
 
 (window as any).game = game;

--- a/src/ui/HUD.ts
+++ b/src/ui/HUD.ts
@@ -9,11 +9,18 @@ export class HUD extends Phaser.Scene {
   stealthBar!: Phaser.GameObjects.Rectangle;
   alert!: Phaser.GameObjects.Text;
   statsText!: Phaser.GameObjects.Text;
-  slots: Phaser.GameObjects.Sprite[] = [];
+  inventorySlots: Phaser.GameObjects.Sprite[] = [];
+  private uiRoot?: Phaser.GameObjects.Container;
+  private resizeHandler = (gameSize: Phaser.Structs.Size) => {
+    this.layoutUI(gameSize);
+  };
+  private barFillWidth = 0;
 
   private static readonly BAR_WIDTH = 120;
   private static readonly BAR_HEIGHT = 10;
   private static readonly BAR_LERP = 0.2;
+  private static readonly BAR_SCALE = 1.6;
+  private static readonly BAR_INSET = 6;
 
   constructor() {
     super('hud');
@@ -24,119 +31,246 @@ export class HUD extends Phaser.Scene {
   }
 
   create(): void {
-    const add = this.add;
-    const width = this.scale.width;
-    const height = this.scale.height;
-    const bottom = height - 36;
+    this.layoutUI(this.scale.gameSize);
+    this.scale.on('resize', this.resizeHandler);
+    this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
+      this.scale.off('resize', this.resizeHandler);
+    });
+    this.cameras.main.setScroll(0, 0);
+  }
 
-    const hpY = bottom - 32;
-    const manaY = bottom - 14;
-    const hpLabel = add
-      .text(16, hpY, 'HP', { fontSize: '12px', color: '#fceaea' })
-      .setOrigin(0, 0.5)
-      .setAlpha(0.85);
-    const hpBg = add
-      .rectangle(48, hpY, HUD.BAR_WIDTH, HUD.BAR_HEIGHT, 0x111111)
-      .setOrigin(0, 0.5)
-      .setStrokeStyle(1, 0x2a2a2a)
-      .setAlpha(0.85);
-    this.hpBar = add
-      .rectangle(48, hpY, HUD.BAR_WIDTH, HUD.BAR_HEIGHT, 0xe74c3c)
-      .setOrigin(0, 0.5)
-      .setAlpha(0.9);
+  private layoutUI(gameSize: Phaser.Structs.Size): void {
+    const width = gameSize.width;
+    const height = gameSize.height;
+    this.uiRoot?.destroy(true);
+    const root = this.add.container(0, 0);
+    this.uiRoot = root;
 
-    const manaLabel = add
-      .text(16, manaY, 'Mana', { fontSize: '12px', color: '#e0f0ff' })
-      .setOrigin(0, 0.5)
-      .setAlpha(0.85);
-    const manaBg = add
-      .rectangle(48, manaY, HUD.BAR_WIDTH, HUD.BAR_HEIGHT, 0x111111)
-      .setOrigin(0, 0.5)
-      .setStrokeStyle(1, 0x2a2a2a)
-      .setAlpha(0.85);
-    this.manaBar = add
-      .rectangle(48, manaY, HUD.BAR_WIDTH, HUD.BAR_HEIGHT, 0x3498db)
-      .setOrigin(0, 0.5)
-      .setAlpha(0.9);
+    const addRect = (...args: Parameters<Phaser.GameObjects.GameObjectFactory['rectangle']>) => {
+      const rect = this.add.rectangle(...args);
+      root.add(rect);
+      return rect;
+    };
+    const addSprite = (...args: Parameters<Phaser.GameObjects.GameObjectFactory['sprite']>) => {
+      const sprite = this.add.sprite(...args);
+      root.add(sprite);
+      return sprite;
+    };
+    const addText = (...args: Parameters<Phaser.GameObjects.GameObjectFactory['text']>) => {
+      const text = this.add.text(...args);
+      root.add(text);
+      return text;
+    };
 
-    hpLabel.setDepth(1);
-    manaLabel.setDepth(1);
-    hpBg.setDepth(0);
-    manaBg.setDepth(0);
+    const panelHeight = 160;
+    const panelTop = height - panelHeight;
+    const panelCenterY = panelTop + panelHeight / 2;
+    const panelPadding = 24;
 
-    const inventoryY = bottom - 26;
-    const slotSpacing = 36;
-    const slotStartX = width / 2 - slotSpacing * 1.5;
-    add
-      .text(width / 2, inventoryY - 22, 'Inventory', {
-        fontSize: '12px',
-        color: '#f4f1de'
-      })
-      .setOrigin(0.5, 0.5)
-      .setAlpha(0.9);
-
-    this.slots = [];
-    for (let i = 0; i < 4; i++) {
-      const slot = add
-        .sprite(slotStartX + i * slotSpacing, inventoryY, SpriteKeys.effects, EffectFrames.chest)
-        .setDisplaySize(32, 32)
-        .setOrigin(0.5, 0.5)
-        .setTint(0x555555)
-        .setAlpha(0.85);
-      this.slots.push(slot);
+    const abilityKeys = ['Q', 'W', 'E', 'R'];
+    let abilitySlotSize = Phaser.Math.Clamp(width / 9, 64, 140);
+    let abilityGap = Phaser.Math.Clamp(abilitySlotSize * 0.18, 12, 32);
+    let totalAbilityWidth = abilityKeys.length * abilitySlotSize + (abilityKeys.length - 1) * abilityGap;
+    const availableTrayWidth = Math.max(width - panelPadding * 2, 0);
+    if (totalAbilityWidth > availableTrayWidth && availableTrayWidth > 0) {
+      abilitySlotSize = Phaser.Math.Clamp(
+        (availableTrayWidth - abilityGap * (abilityKeys.length - 1)) / abilityKeys.length,
+        32,
+        abilitySlotSize
+      );
+      totalAbilityWidth = abilityKeys.length * abilitySlotSize + (abilityKeys.length - 1) * abilityGap;
+      if (totalAbilityWidth > availableTrayWidth) {
+        abilityGap = Phaser.Math.Clamp(
+          (availableTrayWidth - abilitySlotSize * abilityKeys.length) / (abilityKeys.length - 1),
+          4,
+          abilityGap
+        );
+        totalAbilityWidth = abilityKeys.length * abilitySlotSize + (abilityKeys.length - 1) * abilityGap;
+      }
+    }
+    abilitySlotSize = Math.min(abilitySlotSize, panelHeight - panelPadding - 12);
+    totalAbilityWidth = abilityKeys.length * abilitySlotSize + (abilityKeys.length - 1) * abilityGap;
+    let abilityStartX = width / 2 - totalAbilityWidth / 2 + abilitySlotSize / 2;
+    let abilityLeftEdge = abilityStartX - abilitySlotSize / 2;
+    let abilityRightEdge = abilityLeftEdge + totalAbilityWidth;
+    if (abilityLeftEdge < panelPadding) {
+      abilityLeftEdge = panelPadding;
+      abilityRightEdge = abilityLeftEdge + totalAbilityWidth;
+      abilityStartX = abilityLeftEdge + abilitySlotSize / 2;
+    }
+    if (abilityRightEdge > width - panelPadding) {
+      abilityRightEdge = width - panelPadding;
+      abilityLeftEdge = abilityRightEdge - totalAbilityWidth;
+      abilityStartX = abilityLeftEdge + abilitySlotSize / 2;
     }
 
-    const statsX = slotStartX + slotSpacing * 2 + 64;
-    add
-      .text(statsX, inventoryY - 22, 'Stats', { fontSize: '12px', color: '#dcdcdc' })
-      .setOrigin(0, 0.5)
-      .setAlpha(0.9);
-    this.statsText = add
-      .text(statsX, inventoryY + 2, '', { fontSize: '12px', color: '#f4f1de' })
-      .setOrigin(0, 0.5)
-      .setAlpha(0.9);
+    addRect(width / 2, panelCenterY, width, panelHeight, 0x060a12)
+      .setStrokeStyle(2, 0x1c2738)
+      .setAlpha(0.92);
 
-    const stealthY = bottom - 28;
-    const stealthLabelX = width - 220;
-    add
-      .text(stealthLabelX, stealthY - 16, 'Stealth', { fontSize: '12px', color: '#c8f7c5' })
-      .setOrigin(0, 0.5)
-      .setAlpha(0.9);
-    const stealthBg = add
-      .rectangle(stealthLabelX, stealthY, HUD.BAR_WIDTH, HUD.BAR_HEIGHT, 0x111111)
-      .setOrigin(0, 0.5)
-      .setStrokeStyle(1, 0x2a2a2a)
-      .setAlpha(0.85);
-    this.stealthBar = add
-      .rectangle(stealthLabelX, stealthY, HUD.BAR_WIDTH, HUD.BAR_HEIGHT, 0x2ecc71)
-      .setOrigin(0, 0.5)
-      .setAlpha(0.9);
-    stealthBg.setDepth(0);
+    const heroPanelX = panelPadding + 60;
+    const heroPanelY = height - 92;
+    addRect(heroPanelX, heroPanelY, 140, 128, 0x0b1724).setStrokeStyle(2, 0x2c425b).setAlpha(0.95);
 
-    this.alert = add
-      .text(width - 160, bottom - 8, 'No alerts', { fontSize: '12px', color: '#ffffff' })
+    const portrait = addSprite(heroPanelX, heroPanelY - 6, SpriteKeys.effects, EffectFrames.chest)
+      .setDisplaySize(96, 96)
+      .setTint(0x8ca0bf)
+      .setAlpha(0.95);
+    addText(heroPanelX, portrait.y + 64, 'Lvl 12', { fontSize: '14px', color: '#f0d080' })
+      .setOrigin(0.5, 0.5)
+      .setShadow(1, 1, '#000000', 2, true, true);
+
+    const heroPanelRightEdge = heroPanelX + 70;
+    const minBarStart = heroPanelRightEdge + 16;
+    let barStartX = Math.max(heroPanelX + 96, minBarStart);
+    const barEndX = abilityLeftEdge - 28;
+    const desiredBarWidth = HUD.BAR_WIDTH * HUD.BAR_SCALE;
+    const minBarWidth = 140;
+    let availableWidth = barEndX - barStartX;
+    let scaledBarWidth = Phaser.Math.Clamp(availableWidth, minBarWidth, desiredBarWidth);
+
+    if (availableWidth < minBarWidth) {
+      const fallbackWidth = Phaser.Math.Clamp(barEndX - minBarStart, 96, desiredBarWidth);
+      barStartX = Math.max(minBarStart, barEndX - fallbackWidth);
+      availableWidth = barEndX - barStartX;
+      scaledBarWidth = Math.max(availableWidth, 80);
+    }
+
+    scaledBarWidth = Math.min(scaledBarWidth, Math.max(barEndX - barStartX, 0));
+
+    const hpY = panelTop + panelPadding + 12;
+    const barVerticalSpacing = 34;
+    const manaY = hpY + barVerticalSpacing;
+    const stealthY = manaY + barVerticalSpacing;
+
+    const labelStyle = { fontSize: '14px', color: '#f3f5fa' } as Phaser.Types.GameObjects.Text.TextStyle;
+    const barBgColor = 0x111a26;
+
+    addText(barStartX, hpY - 12, 'HEALTH', labelStyle).setOrigin(0, 1).setAlpha(0.9);
+    const insetWidth = scaledBarWidth - HUD.BAR_INSET;
+    const insetOffset = HUD.BAR_INSET / 2;
+    this.barFillWidth = Math.max(insetWidth, 0);
+
+    addRect(barStartX, hpY, scaledBarWidth, HUD.BAR_HEIGHT + 6, barBgColor)
       .setOrigin(0, 0.5)
-      .setAlpha(0.8);
+      .setStrokeStyle(2, 0x365d40)
+      .setAlpha(0.95);
+    this.hpBar = addRect(barStartX + insetOffset, hpY, insetWidth, HUD.BAR_HEIGHT + 2, 0x3fd25d)
+      .setOrigin(0, 0.5)
+      .setAlpha(0.95);
+
+    addText(barStartX, manaY - 12, 'MANA', labelStyle).setOrigin(0, 1).setAlpha(0.9);
+    addRect(barStartX, manaY, scaledBarWidth, HUD.BAR_HEIGHT + 6, barBgColor)
+      .setOrigin(0, 0.5)
+      .setStrokeStyle(2, 0x2f3f6a)
+      .setAlpha(0.95);
+    this.manaBar = addRect(barStartX + insetOffset, manaY, insetWidth, HUD.BAR_HEIGHT + 2, 0x48b0f1)
+      .setOrigin(0, 0.5)
+      .setAlpha(0.95);
+
+    addText(barStartX, stealthY - 12, 'STEALTH', labelStyle).setOrigin(0, 1).setAlpha(0.9);
+    addRect(barStartX, stealthY, scaledBarWidth, HUD.BAR_HEIGHT + 6, barBgColor)
+      .setOrigin(0, 0.5)
+      .setStrokeStyle(2, 0x295746)
+      .setAlpha(0.95);
+    this.stealthBar = addRect(barStartX + insetOffset, stealthY, insetWidth, HUD.BAR_HEIGHT + 2, 0x59e3a5)
+      .setOrigin(0, 0.5)
+      .setAlpha(0.95);
+
+    const abilityTrayPadding = 18;
+    const abilityTrayHeight = abilitySlotSize + abilityTrayPadding;
+    const abilityY = panelTop + panelHeight - abilityTrayHeight / 2 - 12;
+    const trayWidth = abilityRightEdge - abilityLeftEdge + abilityTrayPadding * 2;
+    addRect(abilityLeftEdge + totalAbilityWidth / 2, abilityY, trayWidth, abilityTrayHeight, 0x08101a)
+      .setStrokeStyle(2, 0x284257)
+      .setAlpha(0.92);
+    const keyTagStyle = { fontSize: '12px', color: '#f9fbff' } as Phaser.Types.GameObjects.Text.TextStyle;
+    abilityKeys.forEach((key, index) => {
+      const x = abilityStartX + index * (abilitySlotSize + abilityGap);
+      addRect(x, abilityY, abilitySlotSize, abilitySlotSize, 0x0d1c29)
+        .setStrokeStyle(2, 0x385b7a)
+        .setAlpha(0.95);
+      const iconSize = Math.max(abilitySlotSize - 12, abilitySlotSize * 0.65, 0);
+      const icon = addSprite(x, abilityY, SpriteKeys.effects, EffectFrames.chest)
+        .setDisplaySize(iconSize, iconSize)
+        .setTint(0xbac3d1)
+        .setAlpha(0.92);
+      icon.depth = 1;
+      const keyTagWidth = Math.max(Math.min(26, abilitySlotSize - 6), 18);
+      const keyTagHeight = Math.max(Math.min(18, abilitySlotSize - 8), 12);
+      const keyTagHorizontalMargin = Math.max(
+        Math.min(abilitySlotSize / 2 - keyTagWidth / 2 - 2, 18),
+        4
+      );
+      const keyTagVerticalMargin = Math.max(Math.min(abilitySlotSize * 0.08, 10), 4);
+      const keyTagX = x - abilitySlotSize / 2 + keyTagHorizontalMargin;
+      const keyTagY = abilityY + abilitySlotSize / 2 - keyTagHeight / 2 - keyTagVerticalMargin;
+      addRect(keyTagX, keyTagY, keyTagWidth, keyTagHeight, 0x1a2b3b)
+        .setStrokeStyle(1, 0x385b7a)
+        .setOrigin(0, 0.5)
+        .setAlpha(0.92);
+      addText(keyTagX + keyTagWidth / 2, keyTagY, key, keyTagStyle).setOrigin(0.5, 0.5).setAlpha(0.95);
+    });
+
+    const inventoryTitleX = Math.min(width - panelPadding - 260, abilityRightEdge + 48);
+    addText(inventoryTitleX, panelTop + 20, 'Inventory', {
+      fontSize: '16px',
+      color: '#f4e5c3'
+    })
+      .setOrigin(0, 0.5)
+      .setShadow(1, 1, '#000000', 2, true, true);
+
+    this.inventorySlots = [];
+    const inventoryRows = 2;
+    const inventoryCols = 3;
+    const inventorySpacing = 70;
+    const inventoryStartX = inventoryTitleX + 20;
+    const inventoryStartY = panelTop + panelPadding + 32;
+    for (let row = 0; row < inventoryRows; row++) {
+      for (let col = 0; col < inventoryCols; col++) {
+        const slotX = inventoryStartX + col * inventorySpacing;
+        const slotY = inventoryStartY + row * inventorySpacing;
+        addRect(slotX, slotY, 64, 64, 0x0d1c29).setStrokeStyle(2, 0x5a441e).setAlpha(0.9);
+        const slot = addSprite(slotX, slotY, SpriteKeys.effects, EffectFrames.chest)
+          .setDisplaySize(58, 58)
+          .setTint(0x8a7343)
+          .setAlpha(0.92);
+        this.inventorySlots.push(slot);
+      }
+    }
+
+    const statsX = inventoryStartX + inventorySpacing * inventoryCols + 48;
+    addText(statsX, panelTop + 20, 'Hero Stats', { fontSize: '16px', color: '#d0e6ff' })
+      .setOrigin(0, 0.5)
+      .setShadow(1, 1, '#000000', 2, true, true);
+    this.statsText = addText(statsX, panelTop + 58, '', { fontSize: '14px', color: '#f4f8ff' })
+      .setOrigin(0, 0)
+      .setLineSpacing(6)
+      .setAlpha(0.92);
+
+    const alertY = panelTop + panelHeight - panelPadding - 10;
+    this.alert = addText(statsX, alertY, 'No alerts', { fontSize: '14px', color: '#ffe29f' })
+      .setOrigin(0, 0.5)
+      .setShadow(1, 1, '#000000', 2, true, true);
 
     const setAlert = (msg: string) => this.alert.setText(msg);
     (this.game as unknown as { setAlert?: (msg: string) => void }).setAlert = setAlert;
     (globalThis as { setAlert?: (msg: string) => void }).setAlert = setAlert;
-
-    this.cameras.main.setScroll(0, 0);
   }
 
   update(): void {
     const stats = this.world.hero.stats;
-    const hpTarget = HUD.BAR_WIDTH * (stats.hp / stats.maxHp);
-    const manaTarget = HUD.BAR_WIDTH * (stats.mana / stats.maxMana);
-    const stealthTarget = HUD.BAR_WIDTH * (stats.stealth / stats.stealthMax);
+    const fullBarWidth = this.barFillWidth;
+    const hpTarget = fullBarWidth * (stats.hp / stats.maxHp);
+    const manaTarget = fullBarWidth * (stats.mana / stats.maxMana);
+    const stealthTarget = fullBarWidth * (stats.stealth / stats.stealthMax);
 
     this.hpBar.width = this.lerpBar(this.hpBar.width, hpTarget);
     this.manaBar.width = this.lerpBar(this.manaBar.width, manaTarget);
     this.stealthBar.width = this.lerpBar(this.stealthBar.width, stealthTarget);
 
     this.statsText.setText(
-      `Gold ${stats.gold} | SPD ${this.world.hero.speed.toFixed(1)} | Mana ${stats.mana}/${stats.maxMana}`
+      `Gold ${stats.gold}\nSPD ${this.world.hero.speed.toFixed(1)}\nMana ${stats.mana}/${stats.maxMana}`
     );
   }
 


### PR DESCRIPTION
## Summary
- stretch the game canvas to fill the browser viewport and resize with window changes
- rebuild the HUD scene into a container-driven layout that recomputes spacing whenever the game size updates
- clamp ability tray, resource bars, and key tags so their geometry scales cleanly across wide and narrow displays

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e41c8d22208332939d46781f7bf40a