### PR TITLE
Add placeholder 3D scaffolding

### DIFF
--- a/src/three/Effects.tsx
+++ b/src/three/Effects.tsx
@@ -1,0 +1,11 @@
+import { useEffect } from "react";
+
+const Effects = (): null => {
+  useEffect(() => {
+    console.log("Effects3D mounted");
+  }, []);
+
+  return null;
+};
+
+export default Effects;

--- a/src/three/Player3D.tsx
+++ b/src/three/Player3D.tsx
@@ -1,0 +1,11 @@
+import { useEffect } from "react";
+
+const Player3D = (): null => {
+  useEffect(() => {
+    console.log("Player3D mounted");
+  }, []);
+
+  return null;
+};
+
+export default Player3D;

--- a/src/three/Terrain.tsx
+++ b/src/three/Terrain.tsx
@@ -1,0 +1,11 @@
+import { useEffect } from "react";
+
+const Terrain = (): null => {
+  useEffect(() => {
+    console.log("Terrain3D mounted");
+  }, []);
+
+  return null;
+};
+
+export default Terrain;

--- a/src/three/World3D.tsx
+++ b/src/three/World3D.tsx
@@ -1,0 +1,11 @@
+import { useEffect } from "react";
+
+const World3D = (): null => {
+  useEffect(() => {
+    console.log("World3D mounted");
+  }, []);
+
+  return null;
+};
+
+export default World3D;


### PR DESCRIPTION
## Summary
- create a new src/three directory to organize upcoming Three.js work
- add placeholder Terrain, Player3D, Effects, and World3D components that log when mounted

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ea584dcf0883328cd456999ee85360