### PR TITLE
Add orthographic World3D scene composition

### DIFF
--- a/src/three/Effects.tsx
+++ b/src/three/Effects.tsx
@@ -273,4 +273,5 @@ const Effects = (): JSX.Element => (
   </>
 );
 
+export { AnimatedFog, DayNightCycle, BiomeParticles, AmbientSound };
 export default Effects;

--- a/src/three/World3D.tsx
+++ b/src/three/World3D.tsx
@@ -1,11 +1,34 @@
-import { useEffect } from "react";
+import { useCallback, useState } from "react";
+import { Canvas } from "@react-three/fiber";
+import { OrbitControls } from "@react-three/drei";
+import { Vector3 } from "three";
+import Terrain from "./Terrain";
+import Player3D from "./Player3D";
+import { AnimatedFog, DayNightCycle, BiomeParticles, AmbientSound } from "./Effects";
 
-const World3D = (): null => {
-  useEffect(() => {
-    console.log("World3D mounted");
+const CAMERA_POSITION: [number, number, number] = [60, 80, 60];
+const BIOME_PARTICLE_INSTANCES = 3;
+
+const World3D = (): JSX.Element => {
+  const [target, setTarget] = useState<Vector3 | null>(null);
+
+  const handleSurfaceClick = useCallback((point: Vector3) => {
+    setTarget(point);
   }, []);
 
-  return null;
+  return (
+    <Canvas orthographic camera={{ position: CAMERA_POSITION, zoom: 40 }} shadows>
+      <Terrain onSurfaceClick={handleSurfaceClick} />
+      <Player3D target={target} />
+      <AnimatedFog />
+      <DayNightCycle />
+      {Array.from({ length: BIOME_PARTICLE_INSTANCES }).map((_, index) => (
+        <BiomeParticles key={index} />
+      ))}
+      <AmbientSound />
+      <OrbitControls enableRotate={false} enableZoom />
+    </Canvas>
+  );
 };
 
 export default World3D;


### PR DESCRIPTION
## Summary
- add an orthographic Canvas-based World3D scene that wires terrain clicks, the moving player, atmospheric fog, lighting, particles, audio, and controls
- expose the individual effect components for reuse alongside the combined Effects entry point

## Testing
- npm run lint --prefix web
- npm run test --prefix web

------
https://chatgpt.com/codex/tasks/task_e_68ea5fd3117483329c61ffd22bd7fe8f