### PR TITLE
Integrate World3D clicks with Phaser hero movement

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,14 +1,49 @@
 import Phaser from 'phaser';
-import BootScene from './scenes/BootScene';
-import GameScene from './scenes/GameScene';
-import UIScene from ./scenes/UIScene';
+import { createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { Boot } from './scenes/Boot';
+import { World } from './scenes/World';
+import { HUD } from './ui/HUD';
+import World3D from './three/World3D';
+
+const appElement = document.getElementById('app');
+
+if (!appElement) {
+  throw new Error('App root element not found.');
+}
+
+const wrapper = document.createElement('div');
+wrapper.style.position = 'relative';
+wrapper.style.width = '100%';
+wrapper.style.height = '100%';
+wrapper.style.overflow = 'hidden';
+
+const phaserContainer = document.createElement('div');
+phaserContainer.id = 'phaser-root';
+phaserContainer.style.position = 'absolute';
+phaserContainer.style.inset = '0';
+phaserContainer.style.width = '100%';
+phaserContainer.style.height = '100%';
+phaserContainer.style.zIndex = '0';
+
+const world3dContainer = document.createElement('div');
+world3dContainer.id = 'world3d-root';
+world3dContainer.style.position = 'absolute';
+world3dContainer.style.inset = '0';
+world3dContainer.style.width = '100%';
+world3dContainer.style.height = '100%';
+world3dContainer.style.zIndex = '1';
+
+wrapper.appendChild(phaserContainer);
+wrapper.appendChild(world3dContainer);
+appElement.replaceChildren(wrapper);
 
 const config: Phaser.Types.Core.GameConfig = {
   type: Phaser.AUTO,
-  parent: 'app',
+  parent: phaserContainer,
   backgroundColor: '#0f0f13',
-  width: 800,
-  height: 600,
+  width: window.innerWidth,
+  height: window.innerHeight,
   physics: {
     default: 'arcade',
     arcade: {
@@ -16,10 +51,20 @@ const config: Phaser.Types.Core.GameConfig = {
       debug: false,
     },
   },
-  scene: [BootScene, GameScene, UIScene],
+  scale: {
+    mode: Phaser.Scale.RESIZE,
+    autoCenter: Phaser.Scale.CENTER_BOTH,
+  },
+  scene: [Boot, World, HUD],
 };
 
 const game = new Phaser.Game(config);
 
-// Expose game for debug purposes
+const root = createRoot(world3dContainer);
+root.render(createElement(World3D));
+
+window.addEventListener('resize', () => {
+  game.scale.resize(window.innerWidth, window.innerHeight);
+});
+
 (window as any).game = game;

--- a/src/three/World3D.tsx
+++ b/src/three/World3D.tsx
@@ -2,9 +2,10 @@ import { useCallback, useState } from "react";
 import { Canvas } from "@react-three/fiber";
 import { OrbitControls } from "@react-three/drei";
 import { Vector3 } from "three";
-import Terrain from "./Terrain";
+import Terrain, { TERRAIN_SIZE } from "./Terrain";
 import Player3D from "./Player3D";
 import { AnimatedFog, DayNightCycle, BiomeParticles, AmbientSound } from "./Effects";
+import type { HeroMoveEventDetail } from "../types";
 
 const CAMERA_POSITION: [number, number, number] = [60, 80, 60];
 const BIOME_PARTICLE_INSTANCES = 3;
@@ -14,6 +15,15 @@ const World3D = (): JSX.Element => {
 
   const handleSurfaceClick = useCallback((point: Vector3) => {
     setTarget(point);
+
+    const clamp = (value: number) => Math.min(Math.max(value, 0), 1);
+    const normalizedX = clamp((point.x + TERRAIN_SIZE / 2) / TERRAIN_SIZE);
+    const normalizedY = clamp((point.z + TERRAIN_SIZE / 2) / TERRAIN_SIZE);
+    const detail: HeroMoveEventDetail = {
+      normalized: { x: normalizedX, y: normalizedY }
+    };
+
+    window.dispatchEvent(new CustomEvent<HeroMoveEventDetail>("hero-move", { detail }));
   }, []);
 
   return (

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,3 +19,15 @@ export interface Stats {
   atk?: number;
   speedMult?: number;
 }
+
+export type NormalizedPosition = { x: number; y: number };
+
+export type HeroMoveEventDetail = {
+  normalized: NormalizedPosition;
+};
+
+declare global {
+  interface WindowEventMap {
+    'hero-move': CustomEvent<HeroMoveEventDetail>;
+  }
+}


### PR DESCRIPTION
## Summary
- create shared DOM containers so the Phaser game and World3D scene render together
- forward terrain pointer events to both engines and emit `hero-move` custom events from the 3D canvas
- listen for hero-move events inside the Phaser world scene and centralize hero targeting helpers

## Testing
- npm run lint --prefix web
- npm run test --prefix web

------
https://chatgpt.com/codex/tasks/task_e_68ea60c1f7e88332958ee2871e38ceb2