### PR TITLE
Align 3D clicks with Phaser grid

### DIFF
--- a/src/scenes/World.ts
+++ b/src/scenes/World.ts
@@ -62,7 +62,8 @@ export class World extends Phaser.Scene {
   private _objective!: { goal: number };
   private heroBaseSpeed = 3.5;
   private onHeroMove = (event: WindowEventMap['hero-move']) => {
-    const normalized = event.detail?.normalized;
+    const detail = event.detail;
+    const normalized = detail?.normalized;
     if (!normalized) {
       return;
     }
@@ -73,6 +74,15 @@ export class World extends Phaser.Scene {
       x: clampedX * (this.iso.gridWidth - 0.0001),
       y: clampedY * (this.iso.gridHeight - 0.0001)
     };
+
+    if (detail?.world) {
+      console.debug('[World] hero-move', {
+        world: detail.world,
+        normalized: { x: clampedX, y: clampedY },
+        cart
+      });
+    }
+
     const target = this.cartToScreen(cart);
     this.setHeroTarget(target);
   };

--- a/src/three/World3D.tsx
+++ b/src/three/World3D.tsx
@@ -17,10 +17,12 @@ const World3D = (): JSX.Element => {
     setTarget(point);
 
     const clamp = (value: number) => Math.min(Math.max(value, 0), 1);
-    const normalizedX = clamp((point.x + TERRAIN_SIZE / 2) / TERRAIN_SIZE);
-    const normalizedY = clamp((point.z + TERRAIN_SIZE / 2) / TERRAIN_SIZE);
+    const terrainSpan = TERRAIN_SIZE;
+    const normalizedX = clamp(0.5 + (point.x - point.z) / (2 * terrainSpan));
+    const normalizedY = clamp(0.5 + (point.x + point.z) / (2 * terrainSpan));
     const detail: HeroMoveEventDetail = {
-      normalized: { x: normalizedX, y: normalizedY }
+      normalized: { x: normalizedX, y: normalizedY },
+      world: { x: point.x, z: point.z }
     };
 
     window.dispatchEvent(new CustomEvent<HeroMoveEventDetail>("hero-move", { detail }));

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,7 @@ export type NormalizedPosition = { x: number; y: number };
 
 export type HeroMoveEventDetail = {
   normalized: NormalizedPosition;
+  world: { x: number; z: number };
 };
 
 declare global {


### PR DESCRIPTION
## Summary
- transform World3D surface clicks into isometric-aligned normalized coordinates before dispatching hero-move events
- include raw world coordinates in hero-move events and log the mapped tile position inside the Phaser scene for calibration

## Testing
- npm run lint --prefix web
- npm run test --prefix web

------
https://chatgpt.com/codex/tasks/task_e_68ea634123f08332b288c2124ad8ebce